### PR TITLE
Configurator

### DIFF
--- a/src/configurator/__init__.py
+++ b/src/configurator/__init__.py
@@ -1,1 +1,1 @@
-from .configurator import configure
+from .configurator import configure, parse_config

--- a/src/configurator/configurator.py
+++ b/src/configurator/configurator.py
@@ -1,40 +1,55 @@
 """Module for configuring a new build"""
 
-import os
+from os import path, getcwd
 import json
 import general
 
 
-def configure(
-    project: general.Project,
-    build_path: str,
-    machine: general.MachineInfo,
-    is_specified_script: bool,
-    specified_script: str,
-    build_system: general.IBuildSystem,
-    config_flags: str,
-    compiler_flags: str,
-    runner: general.IBuildSystem,
-):
+class _ComplexEncoder(json.JSONEncoder):
+    def default(self, o):
+        if hasattr(o, "reprJSON"):
+            return o.reprJSON()
+        else:
+            return json.JSONEncoder.default(self, o)
+
+
+def configure(project: general.Project, build_dict: dict[str, str]):
     """Function to configure a new build and save its configuration to a JSON file"""
 
-    project.build_system = build_system
-    project.runner = runner
+    build_path = generate_build_path(project)
 
-    build_name = input("Name current build:\n")
-    build_path = os.path.join(build_path, build_name)
-    os.makedirs(build_path, exist_ok=True)
+    auth = general.MachineAuthenticationInfo(
+        build_dict["username"], build_dict["password"], int(build_dict["port"])
+    )
 
-    build = general.Build(machine, build_path)
-    build.is_specified_script = is_specified_script
-    build.specified_script = specified_script
-    build.config_flags = config_flags
-    build.compiler_flags = compiler_flags
+    machine = general.MachineInfo(
+        general.Arch(build_dict["arch"].lower()), build_dict["ip"], auth
+    )
+    
+    if "script" in build_dict:
+        build = general.Build(machine, build_path, True, build_dict["script"])
+    else:
+        build = general.Build(machine, build_path, False)
+        
+    build.config_flags = build_dict["config_flags"]
+    build.compiler_flags =  build_dict["compiler_flags"]
 
     project.builds.append(build)
 
     config = build.__dict__
 
-    config_path = os.path.join(build_path, "config.json")
-    with open(config_path, "w", encoding="UTF-8") as file:
-        json.dump(config, file, indent=4)
+    config_name = f"{project.build_system}_{project.runner}.json"
+    with open(config_name, "w", encoding="UTF-8") as file:
+        json.dump(config, file, indent=4, cls=_ComplexEncoder)
+
+
+def generate_build_path(project: general.Project):
+    return path.join(getcwd(), f"{project.build_system}_{project.runner}")
+
+
+def parse_config(project: general.Project):
+    project.builds = []
+    with open("input.json", "r", encoding="UTF-8") as f:
+        input_config = json.load(f)
+        for build in input_config["builds"]:
+            configure(project, build)

--- a/src/configurator/configurator.py
+++ b/src/configurator/configurator.py
@@ -12,6 +12,19 @@ def parse_config(project: general.Project) -> None:
     project.builds = []
     with open("input.yml", "r", encoding="UTF-8") as f:
         input_config = yaml.safe_load(f)
+
+        if not isinstance(input_config["build_system"], str):
+            raise TypeError("Invalid build system type :(, look config file")
+
+        project.build_system = general.build_systems_dict[
+            input_config["build_system"].lower()
+        ]
+
+        if not isinstance(input_config["runner"], str):
+            raise TypeError("Invalid runner type ^~^, look config file")
+
+        project.runner = general.build_systems_dict[input_config["runner"].lower()]
+
         for build in input_config["builds"]:
             configure(
                 project,

--- a/src/configurator/configurator.py
+++ b/src/configurator/configurator.py
@@ -1,19 +1,12 @@
 """Module for configuring a new build"""
 
 from os import path, getcwd
+import pickle
 import json
 import general
 
 
-class _ComplexEncoder(json.JSONEncoder):
-    def default(self, o):
-        if hasattr(o, "reprJSON"):
-            return o.reprJSON()
-        else:
-            return json.JSONEncoder.default(self, o)
-
-
-def configure(project: general.Project, build_dict: dict[str, str]):
+def configure(project: general.Project, build_dict: dict[str, str]) -> None:
     """Function to configure a new build and save its configuration to a JSON file"""
 
     build_path = generate_build_path(project)
@@ -25,29 +18,31 @@ def configure(project: general.Project, build_dict: dict[str, str]):
     machine = general.MachineInfo(
         general.Arch(build_dict["arch"].lower()), build_dict["ip"], auth
     )
-    
+
     if "script" in build_dict:
         build = general.Build(machine, build_path, True, build_dict["script"])
     else:
         build = general.Build(machine, build_path, False)
-        
+
     build.config_flags = build_dict["config_flags"]
-    build.compiler_flags =  build_dict["compiler_flags"]
+    build.compiler_flags = build_dict["compiler_flags"]
 
     project.builds.append(build)
 
     config = build.__dict__
 
-    config_name = f"{project.build_system}_{project.runner}.json"
-    with open(config_name, "w", encoding="UTF-8") as file:
-        json.dump(config, file, indent=4, cls=_ComplexEncoder)
+    config_name = f"{project.build_system}_{project.runner}"
+    with open(config_name, "wb") as file:
+        pickle.dump(config, file)
 
 
-def generate_build_path(project: general.Project):
+def generate_build_path(project: general.Project) -> str:
+    """Function to create path to build"""
     return path.join(getcwd(), f"{project.build_system}_{project.runner}")
 
 
-def parse_config(project: general.Project):
+def parse_config(project: general.Project) -> None:
+    """Module enter function"""
     project.builds = []
     with open("input.json", "r", encoding="UTF-8") as f:
         input_config = json.load(f)

--- a/src/general/general.py
+++ b/src/general/general.py
@@ -176,3 +176,9 @@ class Make(IBuildSystem):
             raise NotImplementedError
 
         return "make -j" + str(cpu_count())
+
+
+build_systems_dict: dict[str, type[IBuildSystem]] = {
+    "cmake": CMake,
+    "make": Make,
+}


### PR DESCRIPTION

This PR refactors the build configurator to improve flexibility and configuration handling.

Switched config format:
1.   Replaced JSON with YAML (yaml.safe_load) for input parsing.
2.   Changed output format to pickle

Refactored configure function:
1.   Function now accepts platform_info and receipt_info instead of raw build dict.
2.   Authentication and machine setup updated accordingly.

Why
YAML is more human-readable and easier to maintain than JSON for complex build configurations.
Separation of platform and receipt information improves structure and reduces coupling.