### PR TITLE
A bunch of fixes from 27.03.26

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,10 @@
 [MAIN]
 ignore-path=./tests
+
+[MESSAGES CONTROL]
+disable=
+    too-many-instance-attributes,
+    too-many-positional-arguments,
+    too-many-return-statements,
+    too-few-public-methods,
+    too-many-locals

--- a/amixis.py
+++ b/amixis.py
@@ -85,7 +85,7 @@ def main():
             ):
                 return 1
 
-            show_profiling_result()
+            show_profiling_result(project)
             return 0
 
         if args.analyze:
@@ -102,7 +102,7 @@ def main():
             ):
                 return 1
 
-            show_profiling_result()
+            show_profiling_result(project)
 
         return 0
 

--- a/amphimixis/cli/commands.py
+++ b/amphimixis/cli/commands.py
@@ -131,46 +131,58 @@ def show_profiling_result(project: general.Project):
 
     obj: ProjectStats = tools.load_project_stats(project)
 
-    if not obj:
+    if not obj or not any(
+        obj[build][exe].executable_run_success
+        for build in obj.keys()
+        for exe in obj[build]
+    ):
         print("\n[!] No profiling data (.scriptout files) were generated.")
         print("\tPlease check amphimixis.log for details.")
-    elif len(obj.keys()) == 1:
+        return
+
+    if len(obj.keys()) == 1:
         print("\n[i] Only one profiling result was generated.")
         print("\tTo compare two results, run profiling again with a different build.")
         print("\tOnce you have two .scriptout files, compare them with:")
         print("\tamixis --compare <file1.scriptout> <file2.scriptout>")
-    else:
-        key1, key2 = list(obj.keys())[:2]
-        executable = None
-        for exe in obj[key1]:
-            if exe in obj[key2]:
-                executable = exe
-                break
+        return
 
-        if executable is None:
-            print(
-                "\tThere is no profiling results for the same executable in different build"
-            )
-            print("\b Maybe you should check profiling errors")
-            return
+    def _find_matching_exe() -> tuple[str, str, str]:
+        found_build1 = None
+        found_build2 = None
+        found_executable = None
+        build_keys = list(obj.keys())
+        for build1_index in range(len(build_keys) - 1):
+            for build2_key in build_keys[build1_index + 1 :]:
+                build1 = obj[build_keys[build1_index]]
+                build2 = obj[build2_key]
 
-        build1_name = obj[key1][executable].build_name
-        build2_name = obj[key2][executable].build_name
+                exe_keys = set(obj[build_keys[build1_index]]) | set(obj[build2_key])
 
-        if build1_name is None or build2_name is None:
-            print("Currupted project.stats file")
-            return
+                for exe in exe_keys:
+                    if (
+                        build1[exe].executable_run_success
+                        and build2[exe].executable_run_success
+                    ):
+                        found_build1 = build_keys[build1_index]
+                        found_build2 = build2_key
+                        found_executable = exe
+                        return found_build1, found_build2, found_executable
+        return "", "", ""
 
-        file1 = (
-            tools.build_filename(build1_name, executable) + constants.PERF_SCRIPT_EXT
+    build1, build2, exe = _find_matching_exe()
+    if not all([build1, build2, exe]):
+        print(
+            "\tThere is no profiling results for the same executable in different build"
         )
+        print("\b Maybe you should check profiling errors")
+        return
 
-        file2 = (
-            tools.build_filename(build2_name, executable) + constants.PERF_SCRIPT_EXT
-        )
+    file1 = tools.build_filename(build1, exe) + constants.PERF_SCRIPT_EXT
+    file2 = tools.build_filename(build2, exe) + constants.PERF_SCRIPT_EXT
 
-        print("\n[>] To compare two profiling results, use:")
-        print(f"\tamixis --compare {file1} {file2}")
+    print("\n[>] To compare two profiling results, use:")
+    print(f"\tamixis --compare {file1} {file2}")
 
 
 def setup_profiling_environment(project: general.Project, ui: general.IUI) -> bool:

--- a/amphimixis/cli/commands.py
+++ b/amphimixis/cli/commands.py
@@ -1,12 +1,12 @@
 """CLI command implementations for Amphimixis."""
 
-import glob
 import shutil
 import tempfile
 from os import path
 
 from amphimixis import Builder, Profiler, Shell, analyze, general, parse_config
-from amphimixis.general import IUI, NullUI
+from amphimixis.general import IUI, NullUI, constants, tools
+from amphimixis.general.general import ProjectStats
 from amphimixis.perf_analyzer import main as compare_perf
 
 
@@ -69,6 +69,7 @@ def run_profile(
         profiler_ = Profiler(project, build, ui)
         successful_execs = profiler_.profile_all(events=events)
         profiler_.save_stats()
+        profiler_.cleanup()
         # if empty return -> error
         # if build.executables is not empty, return not equal build.executables -> error
         # if build.executables is empty, return(found executables for profiling) not empty -> passed
@@ -119,26 +120,51 @@ def run_compare(
     return True
 
 
-def show_profiling_result():
+def show_profiling_result(project: general.Project):
     """Show hint or warning after profiling, based on .scriptout files in current directory."""
 
-    scriptout_files = glob.glob("*.scriptout")
+    obj: ProjectStats = tools.load_project_stats(project)
 
-    if not scriptout_files:
+    if not obj:
         print("\n[!] No profiling data (.scriptout files) were generated.")
         print("\tPlease check amphimixis.log for details.")
-    elif len(scriptout_files) == 1:
+    elif len(obj.keys()) == 1:
         print("\n[i] Only one profiling result was generated.")
         print("\tTo compare two results, run profiling again with a different build.")
         print("\tOnce you have two .scriptout files, compare them with:")
         print("\tamixis --compare <file1.scriptout> <file2.scriptout>")
     else:
-        file1 = path.basename(scriptout_files[0])
-        file2 = path.basename(scriptout_files[1])
+        key1, key2 = list(obj.keys())[:2]
+        executable = None
+        for exe in obj[key1]:
+            if exe in obj[key2]:
+                executable = exe
+                break
+
+        if executable is None:
+            print(
+                "\tThere is no profiling results for the same executable in different build"
+            )
+            print("\b Maybe you should check profiling errors")
+            return
+
+        build1_name = obj[key1][executable].build_name
+        build2_name = obj[key2][executable].build_name
+
+        if build1_name is None or build2_name is None:
+            print("Currupted project.stats file")
+            return
+
+        file1 = (
+            tools.build_filename(build1_name, executable) + constants.PERF_SCRIPT_EXT
+        )
+
+        file2 = (
+            tools.build_filename(build2_name, executable) + constants.PERF_SCRIPT_EXT
+        )
+
         print("\n[>] To compare two profiling results, use:")
         print(f"\tamixis --compare {file1} {file2}")
-        if len(scriptout_files) > 2:
-            print("\t(or pick the files you want)")
 
 
 def setup_profiling_environment(project: general.Project, ui: general.IUI) -> bool:

--- a/amphimixis/cli/commands.py
+++ b/amphimixis/cli/commands.py
@@ -36,7 +36,11 @@ def run_build(
     :param IUI ui: User interface for progress display
     """
 
-    parse_config(project, config_file_path=str(config_file_path), ui=ui)
+    if not project.builds and not parse_config(
+        project, config_file_path=str(config_file_path), ui=ui
+    ):
+        return False
+
     for build in project.builds:
         if not Builder.build_for_linux(project, build, ui):
             ui.mark_failed()
@@ -58,8 +62,10 @@ def run_profile(
     :param IUI ui: User interface for progress display
     """
 
-    if not project.builds:
-        parse_config(project, config_file_path=str(config_file_path), ui=ui)
+    if not project.builds and not parse_config(
+        project, config_file_path=str(config_file_path), ui=ui
+    ):
+        return False
 
     setup_profiling_environment(project, ui)
 

--- a/amphimixis/cli/commands.py
+++ b/amphimixis/cli/commands.py
@@ -63,9 +63,12 @@ def run_profile(
 
     setup_profiling_environment(project, ui)
 
+    success = True
+
     for build in project.builds:
         profiler_ = Profiler(project, build, ui)
         successful_execs = profiler_.profile_all(events=events)
+        profiler_.save_stats()
         # if empty return -> error
         # if build.executables is not empty, return not equal build.executables -> error
         # if build.executables is empty, return(found executables for profiling) not empty -> passed
@@ -73,10 +76,11 @@ def run_profile(
             build.executables and successful_execs != build.executables
         ):
             ui.mark_failed()
-            return False
-        profiler_.save_stats()
-        ui.mark_success("Profiling completed!")
-    return True
+            success = False
+        else:
+            ui.mark_success("Profiling completed!")
+
+    return success
 
 
 def run_compare(

--- a/amphimixis/cli/commands.py
+++ b/amphimixis/cli/commands.py
@@ -76,7 +76,7 @@ def run_profile(
         if not successful_execs or (
             build.executables and successful_execs != build.executables
         ):
-            ui.mark_failed()
+            ui.mark_failed("Some executables failed to be profiled")
             success = False
         else:
             ui.mark_success("Profiling completed!")

--- a/amphimixis/cli/console_animation_printer.py
+++ b/amphimixis/cli/console_animation_printer.py
@@ -41,28 +41,40 @@ class ConsoleAnimationPrinter(IUI):
         self.index = (self.index + 1) % len(self.braille)
         self.draw()
 
-    def mark_success(self, message: str = "") -> None:
-        """Mark as successful."""
+    def mark_success(self, message: str = "", build_id: str = "") -> None:
+        """Mark as successful.
+
+        :param str message: message to display.
+        If empty, leaves the previous message
+        :param str build_id: Build identifier.
+        If empty, leaves the previous identifier
+        """
 
         self.status = "success"
-        if message == "":
-            self.message = "Success!"
-        else:
+        if build_id:
+            self.build_id = build_id
+
+        if message:
             self.message = message
 
         self.draw()
         self.finalize()
 
-    def mark_failed(self, error_message: str = "Failed!") -> None:
+    def mark_failed(self, error_message: str = "", build_id: str = "") -> None:
         """Mark as failed and optionally update message.
 
-        :param str error_message: Message to display for failed build
+        :param str error_message: Message to display for failed build.
+        If empty, leaves the previous message
+        :param str build_id: Build identifier.
+        If empty, leaves the previous identifier
         """
 
         self.status = "failed"
-        if error_message == "":
-            self.message = "Failed!"
-        else:
+
+        if build_id:
+            self.build_id = build_id
+
+        if error_message:
             self.message = error_message
 
         self.draw()

--- a/amphimixis/configurator.py
+++ b/amphimixis/configurator.py
@@ -36,63 +36,58 @@ def parse_config(
 
     if not path.exists(project.path):
         _logger.error("Incorrect project path @_@, check input arguments")
-        ui.update_message("config", "Project path not found")
+        ui.mark_failed("Project path not found")
         return False
 
     project.builds = []
 
+    if not path.exists(config_file_path):
+        _logger.error("Input file path not exists")
+        ui.mark_failed("Input file path not exists")
+        return False
+
     if not validate(config_file_path):
         _logger.error("Incorrect input file")
-        ui.update_message("config", "Incorrect input file")
+        ui.mark_failed("Incorrect input file")
         return False
 
-    try:
-        with open(config_file_path, "r", encoding="UTF-8") as file:
-            input_config = yaml.safe_load(file)
+    with open(config_file_path, "r", encoding="UTF-8") as file:
+        input_config = yaml.safe_load(file)
 
-            build_system = input_config.get("build_system")
-            if build_system is None:
-                if not (build_system := _get_analyzed_build_system()):
-                    _logger.error("Did not find any proper build_system")
-                    ui.update_message("config", "No build system found")
-                    return False
+        build_system = input_config.get("build_system")
+        if build_system is None:
+            if not (build_system := _get_analyzed_build_system()):
+                _logger.error("Did not find any proper build_system")
+                ui.mark_failed("No build system found")
+                return False
 
-            runner = input_config.get("runner")
+        runner = input_config.get("runner")
 
-            project.build_system = build_systems_dict[build_system.lower()]
-            project.runner = build_systems_dict[runner.lower()]
+        project.build_system = build_systems_dict[build_system.lower()]
+        project.runner = build_systems_dict[runner.lower()]
 
-            for build in input_config["builds"]:
+        for build in input_config["builds"]:
 
-                (
-                    executables,
-                    build_machine_info,
-                    run_machine_info,
-                    recipe_info,
-                ) = _configure_build(input_config, build)
+            (
+                executables,
+                build_machine_info,
+                run_machine_info,
+                recipe_info,
+            ) = _configure_build(input_config, build)
 
-                if (
-                    build_machine_info == {}
-                    or run_machine_info == {}
-                    or recipe_info == {}
-                ):
-                    return False
+            if build_machine_info == {} or run_machine_info == {} or recipe_info == {}:
+                return False
 
-                if not _create_build(
-                    project,
-                    build_machine_info,
-                    run_machine_info,
-                    recipe_info,
-                    executables,
-                    ui,
-                ):
-                    ui.update_message("config", "Failed to create build")
-                    return False
-
-    except FileNotFoundError:
-        _logger.error("Error opening file, check input data")
-        ui.update_message("config", "Config file not found")
-        return False
+            if not _create_build(
+                project,
+                build_machine_info,
+                run_machine_info,
+                recipe_info,
+                executables,
+                ui,
+            ):
+                ui.mark_failed("Failed to create build")
+                return False
 
     config_path = path.join(getcwd(), tools.project_name(project) + ".project")
     with open(config_path, "wb") as file:
@@ -274,34 +269,32 @@ def _get_analyzed_build_system() -> str | None:
          analysis was not completed
     """
 
-    try:
-        with open(ANALYZED_FILE_NAME, "r", encoding="UTF-8") as file:
-            analyzed = yaml.safe_load(file)
-            if analyzed:
-                if not isinstance(analyzed, dict):
-                    raise TypeError("Incorrect amphimixis.analyzed")
+    if not path.exists(ANALYZED_FILE_NAME):
+        _logger.warning("Analyzer output file not found")
+        return None
 
-                if "build_systems" not in analyzed:
-                    raise TypeError(
-                        "Missing 'build_systems' key in amphimixis.analyzed"
-                    )
+    with open(ANALYZED_FILE_NAME, "r", encoding="UTF-8") as file:
+        analyzed = yaml.safe_load(file)
+        if analyzed:
+            if not isinstance(analyzed, dict):
+                raise TypeError("Incorrect analyzer output file")
 
-                build_systems = analyzed["build_systems"]
-                if not isinstance(build_systems, list) or not build_systems:
-                    raise TypeError("'Build_systems' must be a non-empty list")
+            if "build_systems" not in analyzed:
+                raise TypeError("Missing 'build_systems' key in analyzer output file")
 
-                if not isinstance(build_systems[0], str):
-                    raise TypeError("Incorrect build systems list")
+            build_systems = analyzed["build_systems"]
+            if not isinstance(build_systems, list) or not build_systems:
+                raise TypeError("'Build_systems' must be a non-empty list")
 
-                build_system = build_systems[0].lower()
-                if (
-                    build_system in build_systems_dict
-                ):  # take first (in priority) found build system
-                    return build_system
+            if not isinstance(build_systems[0], str):
+                raise TypeError("Incorrect build systems list")
 
-            return None
+            build_system = build_systems[0].lower()
+            if (
+                build_system in build_systems_dict
+            ):  # take first (in priority) found build system
+                return build_system
 
-    except FileNotFoundError:
         return None
 
 

--- a/amphimixis/configurator.py
+++ b/amphimixis/configurator.py
@@ -8,7 +8,7 @@ from typing import Any
 import yaml
 
 from amphimixis.build_systems import build_systems_dict
-from amphimixis.general import IUI, NullUI, general
+from amphimixis.general import IUI, NullUI, general, tools
 from amphimixis.general.constants import ANALYZED_FILE_NAME
 from amphimixis.laboratory_assistant import LaboratoryAssistant
 from amphimixis.logger import setup_logger
@@ -94,9 +94,7 @@ def parse_config(
         ui.update_message("config", "Config file not found")
         return False
 
-    config_path = path.join(
-        getcwd(), f"{path.basename(path.normpath(project.path))}.project"
-    )
+    config_path = path.join(getcwd(), tools.project_name(project) + ".project")
     with open(config_path, "wb") as file:
         pickle.dump(project, file)
 

--- a/amphimixis/configurator.py
+++ b/amphimixis/configurator.py
@@ -94,6 +94,12 @@ def parse_config(
         ui.update_message("config", "Config file not found")
         return False
 
+    config_path = path.join(
+        getcwd(), f"{path.basename(path.normpath(project.path))}.project"
+    )
+    with open(config_path, "wb") as file:
+        pickle.dump(project, file)
+
     _logger.info("Configuration completed successfully!")
     return True
 
@@ -196,10 +202,6 @@ def _create_build(  # pylint: disable=R0913,R0914,R0917
     )
 
     project.builds.append(build)
-
-    config_path = path.join(getcwd(), f"{build_name}_config")
-    with open(config_path, "wb") as file:
-        pickle.dump(build, file)
 
     return True
 

--- a/amphimixis/general/__init__.py
+++ b/amphimixis/general/__init__.py
@@ -11,6 +11,7 @@ from amphimixis.general.general import (
     MachineAuthenticationInfo,
     MachineInfo,
     NullUI,
+    ProfileStats,
     Project,
     Toolchain,
     ToolchainAttrs,
@@ -32,4 +33,5 @@ __all__ = [
     "ToolchainAttrs",
     "CompilerFlagsAttrs",
     "CompilerFlags",
+    "ProfileStats",
 ]

--- a/amphimixis/general/__init__.py
+++ b/amphimixis/general/__init__.py
@@ -1,6 +1,6 @@
 """The common module that is used in most other modules"""
 
-from amphimixis.general import constants
+from amphimixis.general import constants, tools
 from amphimixis.general.general import (
     IUI,
     Arch,
@@ -25,6 +25,7 @@ __all__ = [
     "IBuildSystem",
     "MachineAuthenticationInfo",
     "constants",
+    "tools",
     "MachineInfo",
     "MachineAuthenticationInfo",
     "IUI",

--- a/amphimixis/general/__init__.py
+++ b/amphimixis/general/__init__.py
@@ -13,6 +13,7 @@ from amphimixis.general.general import (
     NullUI,
     ProfileStats,
     Project,
+    ProjectStats,
     Toolchain,
     ToolchainAttrs,
 )
@@ -35,4 +36,5 @@ __all__ = [
     "CompilerFlagsAttrs",
     "CompilerFlags",
     "ProfileStats",
+    "ProjectStats",
 ]

--- a/amphimixis/general/constants.py
+++ b/amphimixis/general/constants.py
@@ -2,3 +2,7 @@
 
 AMPHIMIXIS_DIRECTORY_NAME = "amphimixis"
 ANALYZED_FILE_NAME = "amphimixis.analyzed"
+PERF_RECORD_EXT = ".perfdata"
+PERF_SCRIPT_EXT = ".scriptout"
+PERF_ARCHIVE_EXT = ".tar.bz2"
+PERF_STATS_EXT = ".stats"

--- a/amphimixis/general/general.py
+++ b/amphimixis/general/general.py
@@ -292,17 +292,19 @@ class IUI(ABC):
         """
 
     @abstractmethod
-    def mark_success(self, message: str = "") -> None:
+    def mark_success(self, message: str = "", build_id: str = "") -> None:
         """Mark build as successful.
 
         :param str message: Optional message
+        :param str build_id: Build identifier
         """
 
     @abstractmethod
-    def mark_failed(self, error_message: str = "") -> None:
+    def mark_failed(self, error_message: str = "", build_id: str = "") -> None:
         """Mark build as failed.
 
-        :param str error: Optional error message
+        :param str error_message: Optional error message
+        :param str build_id: Build identifier
         """
 
 
@@ -315,8 +317,8 @@ class NullUI(IUI):
     def update_message(self, build_id: str, message: str) -> None:
         pass
 
-    def mark_success(self, message: str = "") -> None:
+    def mark_success(self, message: str = "", build_id: str = "") -> None:
         pass
 
-    def mark_failed(self, error_message: str = "") -> None:
+    def mark_failed(self, error_message: str = "", build_id: str = "") -> None:
         pass

--- a/amphimixis/general/general.py
+++ b/amphimixis/general/general.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import StrEnum
 from os.path import isabs
+from typing import Optional
 
 
 class Arch(StrEnum):
@@ -12,6 +13,35 @@ class Arch(StrEnum):
     X86 = "x86"
     RISCV = "riscv"
     ARM = "arm"
+
+
+# pylint: disable=too-many-instance-attributes
+@dataclass
+class ProfileStats:
+    """Profiling and execution statistics for an executable
+
+    :var str | None build_name: Name of the build.
+    :var str | None executable: Path to the executable file (relative to build dir).
+    :var bool | None executable_run_success: Whether the executable finished successfully.
+    :var str | None real_time: Wall-clock (real) execution time.
+    :var str | None user_time: CPU time spent in user mode.
+    :var str | None kernel_time: CPU time spent in kernel mode.
+    :var str | None perf_stat: Output of `perf stat` command.
+    :var str | None perf_record_name: Filename of the recorded `perf record` data.
+    :var str | None perf_script_name: Filename of the processed `perf script` output.
+    :var str | None perf_script_name: Filename of the archive gathered using `perf archive`.
+    """
+
+    build_name: Optional[str] = None
+    executable: Optional[str] = None
+    executable_run_success: Optional[bool] = None
+    real_time: Optional[str] = None
+    user_time: Optional[str] = None
+    kernel_time: Optional[str] = None
+    perf_stat: Optional[str] = None
+    perf_record_name: Optional[str] = None
+    perf_script_name: Optional[str] = None
+    perf_archive_name: Optional[str] = None
 
 
 @dataclass

--- a/amphimixis/general/general.py
+++ b/amphimixis/general/general.py
@@ -44,6 +44,9 @@ class ProfileStats:
     perf_archive_name: Optional[str] = None
 
 
+ProjectStats = dict[str, dict[str, ProfileStats]]
+
+
 @dataclass
 class MachineAuthenticationInfo:
     """Information about authentication on a remote machine

--- a/amphimixis/general/tools.py
+++ b/amphimixis/general/tools.py
@@ -13,7 +13,13 @@ from amphimixis.general.general import Project
 
 
 def build_filename(build_name: str, executable: str) -> str:
-    """Build a reversible filename."""
+    """Build a readable filename that can be decoded back to original values.
+
+    :param str build_name: Name of the build configuration.
+    :param str executable: Path to the executable relative to the build directory.
+    :return: Filename in ``<escaped-build>..<escaped-executable>`` form.
+    :rtype: str
+    """
 
     escaped_build = escape_filename_part(build_name)
     escaped_executable = escape_filename_part(os.path.normpath(executable))
@@ -21,7 +27,13 @@ def build_filename(build_name: str, executable: str) -> str:
 
 
 def parse_filename(filename: str) -> tuple[str, str]:
-    """Decode a filename produced by `build_filename()`."""
+    """Decode a filename produced by :func:`build_filename`.
+
+    :param str filename: Encoded profiling filename without extension.
+    :return: Original build name and executable path.
+    :rtype: tuple[str, str]
+    :raises ValueError: If `filename` does not contain the expected separator.
+    """
 
     separator = filename.find("..")
     if separator == -1:
@@ -33,7 +45,16 @@ def parse_filename(filename: str) -> tuple[str, str]:
 
 
 def escape_filename_part(value: str) -> str:
-    """Escape a build or executable name for a readable, reversible filename."""
+    """Escape a filename part into a filesystem-friendly reversible form.
+
+    Letters, digits, and `-` are preserved. Other supported characters are
+    replaced with short escape sequences so the original string can be restored
+    by :func:`unescape_filename_part`.
+
+    :param str value: Build name or executable path fragment to encode.
+    :return: Encoded string safe to use inside generated filenames.
+    :rtype: str
+    """
 
     escaped = []
     for char in value:
@@ -51,7 +72,13 @@ def escape_filename_part(value: str) -> str:
 
 
 def unescape_filename_part(value: str) -> str:
-    """Decode a filename part produced by `escape_filename_part()`."""
+    """Decode a value produced by :func:`escape_filename_part`.
+
+    :param str value: Encoded filename fragment.
+    :return: Decoded original string.
+    :rtype: str
+    :raises ValueError: If `value` contains an invalid escape sequence.
+    """
 
     decoded = []
     idx = 0
@@ -88,12 +115,24 @@ def unescape_filename_part(value: str) -> str:
 
 
 def project_name(project: Project):
-    """Generate project name based on project object"""
+    """Return the normalized project directory name.
+
+    :param Project project: Project whose root path is used as the name source.
+    :return: Basename of the normalized project path.
+    :rtype: str
+    """
     return os.path.basename(os.path.normpath(project.path))
 
 
 def load_project_stats(project: Project):
-    """Loads profiler statistics of the project"""
+    """Load serialized profiling statistics for a project.
+
+    The statistics file is resolved from the escaped project name and
+    :data:`PERF_STATS_EXT`.
+
+    :param Project project: Project whose profiling statistics should be loaded.
+    :return: Deserialized profiling statistics object.
+    """
     with open(
         escape_filename_part(project_name(project)) + PERF_STATS_EXT,
         "rb",

--- a/amphimixis/general/tools.py
+++ b/amphimixis/general/tools.py
@@ -58,16 +58,17 @@ def escape_filename_part(value: str) -> str:
 
     escaped = []
     for char in value:
-        if char.isalnum() or char == "-":
-            escaped.append(char)
-        elif char == "_":
-            escaped.append("__")
-        elif char == "/":
-            escaped.append("_s")
-        elif char == ".":
-            escaped.append("_d")
-        else:
-            escaped.append(f"_x{ord(char):02x}_")
+        match char:
+            case "-" | str() if char.isalnum():
+                escaped.append(char)
+            case "_":
+                escaped.append("__")
+            case "/":
+                escaped.append("_s")
+            case ".":
+                escaped.append("_d")
+            case _:
+                escaped.append(f"_x{ord(char):02x}_")
     return "".join(escaped)
 
 
@@ -92,24 +93,24 @@ def unescape_filename_part(value: str) -> str:
         if idx + 1 >= len(value):
             raise ValueError(f"Invalid escaped filename part: {value}")
 
-        marker = value[idx + 1]
-        if marker == "_":
-            decoded.append("_")
-            idx += 2
-        elif marker == "s":
-            decoded.append("/")
-            idx += 2
-        elif marker == "d":
-            decoded.append(".")
-            idx += 2
-        elif marker == "x":
-            hex_end = value.find("_", idx + 2)
-            if hex_end == -1:
+        match value[idx + 1]:
+            case "_":
+                decoded.append("_")
+                idx += 2
+            case "s":
+                decoded.append("/")
+                idx += 2
+            case "d":
+                decoded.append(".")
+                idx += 2
+            case "x":
+                hex_end = value.find("_", idx + 2)
+                if hex_end == -1:
+                    raise ValueError(f"Invalid escaped filename part: {value}")
+                decoded.append(chr(int(value[idx + 2 : hex_end], 16)))
+                idx = hex_end + 1
+            case _:
                 raise ValueError(f"Invalid escaped filename part: {value}")
-            decoded.append(chr(int(value[idx + 2 : hex_end], 16)))
-            idx = hex_end + 1
-        else:
-            raise ValueError(f"Invalid escaped filename part: {value}")
 
     return "".join(decoded)
 

--- a/amphimixis/general/tools.py
+++ b/amphimixis/general/tools.py
@@ -1,0 +1,83 @@
+"""Helpers for building and parsing readable, reversible profiling filenames.
+
+This module contains utility functions for encoding build names and executable
+paths into filesystem-friendly filenames and decoding them back without losing
+information.
+"""
+
+import os
+
+
+def build_filename(build_name: str, executable: str) -> str:
+    """Build a reversible filename."""
+
+    escaped_build = escape_filename_part(build_name)
+    escaped_executable = escape_filename_part(os.path.normpath(executable))
+    return f"{escaped_build}..{escaped_executable}"
+
+
+def parse_filename(filename: str) -> tuple[str, str]:
+    """Decode a filename produced by `build_filename()`."""
+
+    separator = filename.find("..")
+    if separator == -1:
+        raise ValueError(f"Invalid perf record filename: {filename}")
+
+    build_name = unescape_filename_part(filename[:separator])
+    executable = unescape_filename_part(filename[separator + 2 :])
+    return build_name, executable
+
+
+def escape_filename_part(value: str) -> str:
+    """Escape a build or executable name for a readable, reversible filename."""
+
+    escaped = []
+    for char in value:
+        if char.isalnum() or char == "-":
+            escaped.append(char)
+        elif char == "_":
+            escaped.append("__")
+        elif char == "/":
+            escaped.append("_s")
+        elif char == ".":
+            escaped.append("_d")
+        else:
+            escaped.append(f"_x{ord(char):02x}_")
+    return "".join(escaped)
+
+
+def unescape_filename_part(value: str) -> str:
+    """Decode a filename part produced by `escape_filename_part()`."""
+
+    decoded = []
+    idx = 0
+    while idx < len(value):
+        char = value[idx]
+        if char != "_":
+            decoded.append(char)
+            idx += 1
+            continue
+
+        if idx + 1 >= len(value):
+            raise ValueError(f"Invalid escaped filename part: {value}")
+
+        marker = value[idx + 1]
+        if marker == "_":
+            decoded.append("_")
+            idx += 2
+        elif marker == "s":
+            decoded.append("/")
+            idx += 2
+        elif marker == "d":
+            decoded.append(".")
+            idx += 2
+        elif marker == "x":
+            hex_end = value.find("_", idx + 2)
+            if hex_end == -1:
+                raise ValueError(f"Invalid escaped filename part: {value}")
+            decoded.append(chr(int(value[idx + 2 : hex_end], 16)))
+            idx = hex_end + 1
+        else:
+            raise ValueError(f"Invalid escaped filename part: {value}")
+
+    return "".join(decoded)

--- a/amphimixis/general/tools.py
+++ b/amphimixis/general/tools.py
@@ -59,7 +59,7 @@ def escape_filename_part(value: str) -> str:
     escaped = []
     for char in value:
         match char:
-            case "-" | str() if char.isalnum():
+            case char if char.isalnum() or char == "-":
                 escaped.append(char)
             case "_":
                 escaped.append("__")

--- a/amphimixis/general/tools.py
+++ b/amphimixis/general/tools.py
@@ -7,6 +7,8 @@ information.
 
 import os
 
+from amphimixis.general.general import Project
+
 
 def build_filename(build_name: str, executable: str) -> str:
     """Build a reversible filename."""
@@ -81,3 +83,8 @@ def unescape_filename_part(value: str) -> str:
             raise ValueError(f"Invalid escaped filename part: {value}")
 
     return "".join(decoded)
+
+
+def project_name(project: Project):
+    """Generate project name based on project object"""
+    return os.path.basename(os.path.normpath(project.path))

--- a/amphimixis/general/tools.py
+++ b/amphimixis/general/tools.py
@@ -6,7 +6,9 @@ information.
 """
 
 import os
+import pickle
 
+from amphimixis.general.constants import PERF_STATS_EXT
 from amphimixis.general.general import Project
 
 
@@ -88,3 +90,12 @@ def unescape_filename_part(value: str) -> str:
 def project_name(project: Project):
     """Generate project name based on project object"""
     return os.path.basename(os.path.normpath(project.path))
+
+
+def load_project_stats(project: Project):
+    """Loads profiler statistics of the project"""
+    with open(
+        escape_filename_part(project_name(project)) + PERF_STATS_EXT,
+        "rb",
+    ) as file:
+        return pickle.load(file)

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -63,6 +63,8 @@ except ImportError:
 
 DELTA_COLUMN_LENGTH = 7
 LLM_OUTPUT_FILENAME = "perf_llm_output.md"
+LLM_SYMBOL_COLUMN_LENGTH = 60
+LLM_VALUE_COLUMN_LENGTH = 8
 
 
 def _parse_perf_line(line):
@@ -197,11 +199,18 @@ def print_comparison_table(
 
 def _format_df_to_text(event_name, df):
     text = [f"EVENT: {event_name.upper()}"]
-    text.append(f"{'Symbol':<60} | {'A%':>8} | {'B%':>8} | {'Delta%':>8}")
+    text.append(
+        f"{'Symbol':<{LLM_SYMBOL_COLUMN_LENGTH}} | "
+        f"{'A%':>{LLM_VALUE_COLUMN_LENGTH}} | "
+        f"{'B%':>{LLM_VALUE_COLUMN_LENGTH}} | "
+        f"{'Delta%':>{LLM_VALUE_COLUMN_LENGTH}}"
+    )
     for _, r in df.iterrows():
         text.append(
-            f"{r['symbol'][:60]:<60} | {r['share_a']:8.2f} "
-            f"| {r['share_b']:8.2f} | {r['delta']:+8.2f}"
+            f"{r['symbol'][:LLM_SYMBOL_COLUMN_LENGTH]:<{LLM_SYMBOL_COLUMN_LENGTH}} | "
+            f"{r['share_a']:{LLM_VALUE_COLUMN_LENGTH}.2f} | "
+            f"{r['share_b']:{LLM_VALUE_COLUMN_LENGTH}.2f} | "
+            f"{r['delta']:+{LLM_VALUE_COLUMN_LENGTH}.2f}"
         )
     return "\n".join(text)
 

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -265,7 +265,7 @@ def main(
     if not stats_a or not stats_b:
         return 1
 
-    all_events = set(stats_a.keys()) | set(stats_b.keys())
+    all_events = sorted(set(stats_a.keys()) | set(stats_b.keys()))
 
     top_regressions = []
     comparison_table_text = ""

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -85,6 +85,20 @@ def _parse_perf_line(line):
     return symbol, period, event_type
 
 
+def _event_map(event: str) -> str:
+    # intel hybrid cpu with E/P cores
+    # merges cpu_atom/cycles and cpu_core/cycles into a single 'cycles' event
+    # there should be a better solution...
+    if "cycles" in event:
+        return "cycles"
+
+    # risc-v
+    if event == "cpu-clock":
+        return "cycles"
+
+    return event
+
+
 def _get_stats_by_event(filepath):
     # { 'cycles': { 'func1': 100, 'func2': 200 }, 'cache-misses': { ... } }
     event_data = defaultdict(lambda: defaultdict(float))
@@ -95,7 +109,8 @@ def _get_stats_by_event(filepath):
                 res = _parse_perf_line(line)
                 if res:
                     sym, period, ev = res
-                    event_data[ev][sym] += period
+                    event = _event_map(ev)
+                    event_data[event][sym] += period
     except FileNotFoundError:
         return None
 

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -3,6 +3,7 @@
 # pylint: disable=too-many-arguments
 
 import os
+import shutil
 import sys
 from collections import defaultdict
 
@@ -125,6 +126,12 @@ PERCENTAGE_MAX_LENGTH = len("100.00")
 TOTAL_MARGINS = INNER_BORDERS * BUILD_TEXT_MARGINS
 
 
+def _get_terminal_width(default: int = 80) -> int:
+    """Return terminal width or a fallback value if it cannot be detected."""
+
+    return shutil.get_terminal_size(fallback=(default, 24)).columns
+
+
 # pylint: disable=too-many-locals
 def print_comparison_table(
     event_name, data_a, data_b, max_rows, build_a="Build A", build_b="Build B"
@@ -149,7 +156,7 @@ def print_comparison_table(
         PERCENTAGE_MAX_LENGTH, len(build_b) + BUILD_TEXT_MARGINS
     )
     symbol_length = (
-        os.get_terminal_size()[0]
+        _get_terminal_width()
         - build_a_column_length
         - build_b_column_length
         - DELTA_COLUMN_LENGTH
@@ -161,8 +168,9 @@ def print_comparison_table(
     header_a = f"{build_a} %".rjust(build_a_column_length)
     header_b = f"{build_b} %".rjust(build_b_column_length)
     header_delta = "Delta %".rjust(DELTA_COLUMN_LENGTH)
+    event_header = f" EVENT: {event_name.upper()} "
 
-    print(f"\n{'='*10} EVENT: {event_name.upper()} {'='*10}")
+    print(f"\n{event_header.center(_get_terminal_width(), '=')}")
     print(f"{header_symbol} | {header_a} | {header_b} | {header_delta}")
     print(
         "-"

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -252,7 +252,7 @@ def main(
     top_regressions = []
     comparison_table_text = ""
 
-    if not any(event in all_events for event in target_events or []):
+    if False in (event in all_events for event in target_events or []):
         print("Available events: ", *all_events)
         return 1
 

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -56,8 +56,11 @@ except ImportError:
 
     _logger = logging.getLogger("PERF_ANALYZER")
 
-SYMBOL_LENGTH = 160
-COLUMN_LENGTH = 12
+BUILD_COLUMN_LENGTH = 9
+DELTA_COLUMN_LENGTH = 7
+SYMBOL_LENGTH = (
+    os.get_terminal_size()[0] - 3 * BUILD_COLUMN_LENGTH - DELTA_COLUMN_LENGTH
+)
 LLM_OUTPUT_FILENAME = "perf_llm_output.md"
 
 
@@ -110,13 +113,13 @@ def print_comparison_table(event_name, data_a, data_b, max_rows):
     )
 
     header_symbol = "Symbol".ljust(SYMBOL_LENGTH)
-    header_a = "Build A %".rjust(COLUMN_LENGTH)
-    header_b = "Build B %".rjust(COLUMN_LENGTH)
-    header_delta = "Delta %".rjust(COLUMN_LENGTH)
+    header_a = "Build A %".rjust(BUILD_COLUMN_LENGTH)
+    header_b = "Build B %".rjust(BUILD_COLUMN_LENGTH)
+    header_delta = "Delta %".rjust(DELTA_COLUMN_LENGTH)
 
     print(f"\n{'='*10} EVENT: {event_name.upper()} {'='*10}")
     print(f"{header_symbol} | {header_a} | {header_b} | {header_delta}")
-    print("-" * (SYMBOL_LENGTH + COLUMN_LENGTH * 3 + 10))
+    print("-" * (SYMBOL_LENGTH + BUILD_COLUMN_LENGTH * 2 + DELTA_COLUMN_LENGTH + 9))
 
     for _, row in result.iterrows():
         sym = row["symbol"]
@@ -124,9 +127,9 @@ def print_comparison_table(event_name, data_a, data_b, max_rows):
             (sym[: SYMBOL_LENGTH - 3] + "...") if len(sym) > SYMBOL_LENGTH else sym
         )
 
-        val_a = f"{row['share_a']:>{COLUMN_LENGTH}.2f}"
-        val_b = f"{row['share_b']:>{COLUMN_LENGTH}.2f}"
-        val_d = f"{row['delta']:>+{COLUMN_LENGTH}.2f}"
+        val_a = f"{row['share_a']:>{BUILD_COLUMN_LENGTH}.2f}"
+        val_b = f"{row['share_b']:>{BUILD_COLUMN_LENGTH}.2f}"
+        val_d = f"{row['delta']:>+{DELTA_COLUMN_LENGTH}.2f}"
         print(f"{display_sym.ljust(SYMBOL_LENGTH)} | {val_a} | {val_b} | {val_d}")
 
 

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -233,6 +233,12 @@ def main(
     """
     Compares two perf output files and prints the top `max_rows`
     symbols with the most significant changes for specified events.
+
+    :param str filename1: path to baseline build perfdata.scriptout
+    :param str filename2: path to another build perfdata.scriptout
+    :param list[str] target_events: list of events to compare
+    :param int max_rows: maximum symbols to print per event
+    :param bool use_llm: use LLM
     """
 
     stats_a = _get_stats_by_event(filename1)

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -1,11 +1,15 @@
 """Compare two perf output files."""
 
+# pylint: disable=too-many-arguments
+
 import os
 import sys
 from collections import defaultdict
 
 import pandas as pd
 from openai import OpenAI
+
+from amphimixis.general import tools
 
 
 # pylint: disable=too-few-public-methods
@@ -56,11 +60,7 @@ except ImportError:
 
     _logger = logging.getLogger("PERF_ANALYZER")
 
-BUILD_COLUMN_LENGTH = 9
 DELTA_COLUMN_LENGTH = 7
-SYMBOL_LENGTH = (
-    os.get_terminal_size()[0] - 3 * BUILD_COLUMN_LENGTH - DELTA_COLUMN_LENGTH
-)
 LLM_OUTPUT_FILENAME = "perf_llm_output.md"
 
 
@@ -118,7 +118,9 @@ def _get_stats_by_event(filepath):
 
 
 # pylint: disable=too-many-locals
-def print_comparison_table(event_name, data_a, data_b, max_rows):
+def print_comparison_table(
+    event_name, data_a, data_b, max_rows, build_a="Build A", build_b="Build B"
+):
     """Prints statistics comparison for a specific event."""
 
     merged = _get_comparison_data(data_a, data_b, max_rows)
@@ -127,25 +129,49 @@ def print_comparison_table(event_name, data_a, data_b, max_rows):
         max_rows
     )
 
-    header_symbol = "Symbol".ljust(SYMBOL_LENGTH)
-    header_a = "Build A %".rjust(BUILD_COLUMN_LENGTH)
-    header_b = "Build B %".rjust(BUILD_COLUMN_LENGTH)
+    if not build_a:
+        build_a = "Build A"
+    if not build_b:
+        build_b = "Build B"
+
+    build_a_column_length = max(6, len(build_a) + 2)
+    build_b_column_length = max(6, len(build_b) + 2)
+    symbol_length = (
+        os.get_terminal_size()[0]
+        - build_a_column_length
+        - build_b_column_length
+        - DELTA_COLUMN_LENGTH
+        - 10
+    )
+
+    header_symbol = "Symbol".ljust(symbol_length)
+    header_a = f"{build_a} %".rjust(build_a_column_length)
+    header_b = f"{build_b} %".rjust(build_b_column_length)
     header_delta = "Delta %".rjust(DELTA_COLUMN_LENGTH)
 
     print(f"\n{'='*10} EVENT: {event_name.upper()} {'='*10}")
     print(f"{header_symbol} | {header_a} | {header_b} | {header_delta}")
-    print("-" * (SYMBOL_LENGTH + BUILD_COLUMN_LENGTH * 2 + DELTA_COLUMN_LENGTH + 9))
+    print(
+        "-"
+        * (
+            symbol_length
+            + build_a_column_length
+            + build_b_column_length
+            + DELTA_COLUMN_LENGTH
+            + 9
+        )
+    )
 
     for _, row in result.iterrows():
         sym = row["symbol"]
         display_sym = (
-            (sym[: SYMBOL_LENGTH - 3] + "...") if len(sym) > SYMBOL_LENGTH else sym
+            (sym[: symbol_length - 3] + "...") if len(sym) > symbol_length else sym
         )
 
-        val_a = f"{row['share_a']:>{BUILD_COLUMN_LENGTH}.2f}"
-        val_b = f"{row['share_b']:>{BUILD_COLUMN_LENGTH}.2f}"
+        val_a = f"{row['share_a']:>{build_a_column_length}.2f}"
+        val_b = f"{row['share_b']:>{build_b_column_length}.2f}"
         val_d = f"{row['delta']:>+{DELTA_COLUMN_LENGTH}.2f}"
-        print(f"{display_sym.ljust(SYMBOL_LENGTH)} | {val_a} | {val_b} | {val_d}")
+        print(f"{display_sym.ljust(symbol_length)} | {val_a} | {val_b} | {val_d}")
 
 
 def _format_df_to_text(event_name, df):
@@ -201,6 +227,16 @@ def _get_comparison_data(data_a, data_b, max_rows):
     ).head(max_rows)
 
     return top_changes
+
+
+def _get_build_data(filename: str) -> str:
+
+    if not os.path.exists(filename):
+        return ""
+
+    filename = os.path.splitext(filename)[0]
+
+    return tools.parse_filename(filename)[0]
 
 
 def analyze_with_llm(table, samples_a, samples_b):
@@ -259,6 +295,9 @@ def main(
     :param bool use_llm: use LLM
     """
 
+    build_a = _get_build_data(filename1)
+    build_b = _get_build_data(filename2)
+
     stats_a = _get_stats_by_event(filename1)
     stats_b = _get_stats_by_event(filename2)
 
@@ -275,7 +314,9 @@ def main(
         return 1
 
     for event in target_events if target_events else all_events:
-        print_comparison_table(event, stats_a[event], stats_b[event], max_rows)
+        print_comparison_table(
+            event, stats_a[event], stats_b[event], max_rows, build_a, build_b
+        )
 
         df = _get_comparison_data(stats_a[event], stats_b[event], max_rows)
         comparison_table_text += _format_df_to_text(event, df)

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -117,6 +117,14 @@ def _get_stats_by_event(filepath):
     return event_data
 
 
+INNER_BORDERS = 3
+BUILD_TEXT_MARGINS = 2
+BUILD_A_DEFAULT = "Build A"
+BUILD_B_DEFAULT = "Build B"
+PERCENTAGE_MAX_LENGTH = len("100.00")
+TOTAL_MARGINS = INNER_BORDERS * BUILD_TEXT_MARGINS
+
+
 # pylint: disable=too-many-locals
 def print_comparison_table(
     event_name, data_a, data_b, max_rows, build_a="Build A", build_b="Build B"
@@ -134,14 +142,19 @@ def print_comparison_table(
     if not build_b:
         build_b = "Build B"
 
-    build_a_column_length = max(6, len(build_a) + 2)
-    build_b_column_length = max(6, len(build_b) + 2)
+    build_a_column_length = max(
+        PERCENTAGE_MAX_LENGTH, len(build_a) + BUILD_TEXT_MARGINS
+    )
+    build_b_column_length = max(
+        PERCENTAGE_MAX_LENGTH, len(build_b) + BUILD_TEXT_MARGINS
+    )
     symbol_length = (
         os.get_terminal_size()[0]
         - build_a_column_length
         - build_b_column_length
         - DELTA_COLUMN_LENGTH
-        - 10
+        - TOTAL_MARGINS
+        - INNER_BORDERS
     )
 
     header_symbol = "Symbol".ljust(symbol_length)

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -174,16 +174,7 @@ def print_comparison_table(
 
     print(f"\n{event_header.center(_get_terminal_width(), '=')}")
     print(f"{header_symbol} | {header_a} | {header_b} | {header_delta}")
-    print(
-        "-"
-        * (
-            symbol_length
-            + build_a_column_length
-            + build_b_column_length
-            + DELTA_COLUMN_LENGTH
-            + 9
-        )
-    )
+    print("-" * _get_terminal_width())
 
     for _, row in result.iterrows():
         sym = row["symbol"]

--- a/amphimixis/perf_analyzer.py
+++ b/amphimixis/perf_analyzer.py
@@ -339,7 +339,7 @@ def main(
     top_regressions = []
     comparison_table_text = ""
 
-    if False in (event in all_events for event in target_events or []):
+    if not all(event in all_events for event in target_events or []):
         print("Available events: ", *all_events)
         return 1
 

--- a/amphimixis/profiler.py
+++ b/amphimixis/profiler.py
@@ -486,7 +486,8 @@ class Profiler:
 
         if perf_archive_error == 0 and not self.shell.copy_to_host(
             os.path.join(
-                working_directory, self.get_record_filename(executable) + ".tar.bz2"
+                working_directory,
+                self.get_record_filename(executable) + constants.PERF_ARCHIVE_EXT,
             ),
             os.path.join(os.getcwd(), self.get_archive_filename(executable)),
         ):

--- a/amphimixis/profiler.py
+++ b/amphimixis/profiler.py
@@ -5,7 +5,7 @@ import os
 import pickle
 
 from amphimixis import general, logger, shell
-from amphimixis.general import IUI, NullUI, ProfileStats, constants, tools
+from amphimixis.general import IUI, NullUI, ProfileStats, ProjectStats, constants, tools
 
 _commands_args: dict[str, dict[str, str]] = {
     "stat": {
@@ -575,8 +575,7 @@ class Profiler:
             with open(
                 os.path.join(os.getcwd(), self._get_stats_filename()), "rb"
             ) as file:
-                obj: dict[str, dict[str, ProfileStats]]
-                obj = pickle.load(file)
+                obj: ProjectStats = pickle.load(file)
             merged_stats.update(obj)
         except FileNotFoundError:
             pass

--- a/amphimixis/profiler.py
+++ b/amphimixis/profiler.py
@@ -5,7 +5,7 @@ import os
 import pickle
 
 from amphimixis import general, logger, shell
-from amphimixis.general import IUI, NullUI, ProfileStats
+from amphimixis.general import IUI, NullUI, ProfileStats, constants, tools
 
 _commands_args: dict[str, dict[str, str]] = {
     "stat": {
@@ -482,7 +482,9 @@ class Profiler:
         self.stats[executable].perf_record_name = self.get_record_filename(executable)
 
         if perf_archive_error == 0 and not self.shell.copy_to_host(
-            os.path.join(working_directory, self.get_archive_filename(executable)),
+            os.path.join(
+                working_directory, self.get_record_filename(executable) + ".tar.bz2"
+            ),
             os.path.join(os.getcwd(), self.get_archive_filename(executable)),
         ):
             self.logger.error(
@@ -565,15 +567,29 @@ class Profiler:
     def get_record_filename(self, executable: str) -> str:
         """Gets perf record output file name."""
 
-        executable_path_flatten = os.path.normpath(executable).replace("/", "_")
-        return f"{self.build.build_name}_{executable_path_flatten}.perfdata"
+        return (
+            tools.build_filename(self.build.build_name, executable)
+            + constants.PERF_RECORD_EXT
+        )
 
     def get_archive_filename(self, executable: str) -> str:
         """Gets perf archive file name."""
-        return self.get_record_filename(executable) + ".tar.bz2"
+        return (
+            tools.build_filename(self.build.build_name, executable)
+            + constants.PERF_ARCHIVE_EXT
+        )
+
+    def get_script_filename(self, executable: str) -> str:
+        """Gets perf script file name."""
+        return (
+            tools.build_filename(self.build.build_name, executable)
+            + constants.PERF_SCRIPT_EXT
+        )
 
     def _get_stats_filename(self) -> str:
-        return f"{self.build.build_name}.stats"
+        return (
+            tools.escape_filename_part(self.build.build_name) + constants.PERF_STATS_EXT
+        )
 
     def _build_cmd(
         self,
@@ -613,7 +629,9 @@ class Profiler:
     ) -> tuple[str, str]:
         fixed_options = f"-G -i {perf_record_file}"
         if not perf_script_output_file:
-            perf_script_output_file = perf_record_file + ".scriptout"
+            perf_script_output_file = self.get_script_filename(
+                tools.parse_filename(os.path.splitext(perf_record_file)[0])[1]
+            )
 
         return (
             f"perf --no-pager script {user_options} {fixed_options} > {perf_script_output_file}",

--- a/amphimixis/profiler.py
+++ b/amphimixis/profiler.py
@@ -3,24 +3,9 @@
 import logging
 import os
 import pickle
-from enum import Enum
 
 from amphimixis import general, logger, shell
-from amphimixis.general import IUI, NullUI
-
-
-class Stats(Enum):
-    """Profiler stats fields"""
-
-    REAL_TIME = 0
-    USER_TIME = 1
-    KERNEL_TIME = 2
-    EXECUTABLE_RUN_SUCCESS = 3
-    PERF_STAT = 4
-
-
-ProfilerStats = dict[Stats, str]
-
+from amphimixis.general import IUI, NullUI, ProfileStats
 
 _commands_args: dict[str, dict[str, str]] = {
     "stat": {
@@ -72,7 +57,7 @@ class Profiler:
         self.ui = ui
         self.executables = build.executables.copy()
         self.shell = shell.Shell(self.project, self.machine, ui).connect()
-        self.stats: dict[str, ProfilerStats] = {}
+        self.stats: dict[str, ProfileStats] = {}
         self.build_path = os.path.join(
             self.shell.get_project_workdir(), build.build_name
         )
@@ -189,7 +174,10 @@ class Profiler:
         )
 
         if executable not in self.stats:
-            self.stats.update({executable: {}})
+            stats = general.ProfileStats(
+                build_name=self.build.build_name, executable=executable
+            )
+            self.stats.update({executable: stats})
 
         error, _, stderr = self.shell.run(f"cd {working_directory}")
         if error != 0:
@@ -229,13 +217,9 @@ class Profiler:
             self.ui.mark_failed("Execution time measure error. Check the logs")
             return False
 
-        self.stats[executable].update(
-            {
-                Stats.REAL_TIME: stderr[0][-3].strip(),
-                Stats.USER_TIME: stderr[0][-2].strip(),
-                Stats.KERNEL_TIME: stderr[0][-1].strip(),
-            }
-        )
+        self.stats[executable].real_time = stderr[0][-3].strip()
+        self.stats[executable].user_time = stderr[0][-2].strip()
+        self.stats[executable].kernel_time = stderr[0][-1].strip()
 
         self.logger.info(
             "Measuring execution time finished",
@@ -267,7 +251,10 @@ class Profiler:
         )
 
         if executable not in self.stats:
-            self.stats.update({executable: {}})
+            stats = general.ProfileStats(
+                build_name=self.build.build_name, executable=executable
+            )
+            self.stats.update({executable: stats})
 
         error, stdout, stderr = self.shell.run(
             f"cd {working_directory}", f"{os.path.join(self.build_path, executable)}"
@@ -289,9 +276,7 @@ class Profiler:
             )
             self.ui.mark_failed("Smoke test error. Check the logs")
 
-        self.stats[executable].update(
-            {Stats.EXECUTABLE_RUN_SUCCESS: "true" if error == 0 else "false"}
-        )
+        self.stats[executable].executable_run_success = error == 0
 
         self.logger.info(
             "Smoke test finished",
@@ -327,7 +312,10 @@ class Profiler:
         )
 
         if executable not in self.stats:
-            self.stats.update({executable: {}})
+            stats = general.ProfileStats(
+                build_name=self.build.build_name, executable=executable
+            )
+            self.stats.update({executable: stats})
 
         error, _, stderr = self.shell.run(
             f"cd {working_directory}",
@@ -365,7 +353,7 @@ class Profiler:
             self.ui.mark_failed("Perf stat error. Check the logs")
             return False
 
-        self.stats[executable].update({Stats.PERF_STAT: "".join(stderr[0])})
+        self.stats[executable].perf_stat = "".join(stderr[0])
 
         self.logger.info(
             "Perf stat finished",
@@ -472,6 +460,7 @@ class Profiler:
         self.ui.update_message(
             self.build.build_name, "Getting all data from the machine..."
         )
+
         if not self.shell.copy_to_host(
             os.path.join(working_directory, self.get_record_filename(executable)),
             os.path.join(os.getcwd(), self.get_record_filename(executable)),
@@ -484,6 +473,14 @@ class Profiler:
             self.ui.mark_failed("Perf recordfile copy error. Check the logs")
             return False
 
+        if executable not in self.stats:
+            stats = general.ProfileStats(
+                build_name=self.build.build_name, executable=executable
+            )
+            self.stats.update({executable: stats})
+
+        self.stats[executable].perf_record_name = self.get_record_filename(executable)
+
         if perf_archive_error == 0 and not self.shell.copy_to_host(
             os.path.join(working_directory, self.get_archive_filename(executable)),
             os.path.join(os.getcwd(), self.get_archive_filename(executable)),
@@ -494,6 +491,11 @@ class Profiler:
             )
 
             return False
+
+        if perf_archive_error == 0:
+            self.stats[executable].perf_archive_name = self.get_archive_filename(
+                executable
+            )
 
         self.logger.info(
             "Perf record collecting finished",

--- a/amphimixis/profiler.py
+++ b/amphimixis/profiler.py
@@ -393,7 +393,10 @@ class Profiler:
         """
 
         if not events:
-            events = ["cycles", "cache-misses", "branch-misses"]
+            if self.build.run_machine.arch == general.Arch.RISCV:
+                events = ["cpu-clock", "cache-misses", "branch-misses"]
+            else:
+                events = ["cycles", "cache-misses", "branch-misses"]
 
         self.ui.update_message(self.build.build_name, "Perf data recording...")
         self.logger.info(

--- a/amphimixis/profiler.py
+++ b/amphimixis/profiler.py
@@ -562,10 +562,27 @@ class Profiler:
         return True, perf_script_file
 
     def save_stats(self):
-        """Save collected statistics to a file."""
+        """Save collected statistics to a file.
+        Merges with previous build statistics.
+
+        Structure:
+        {"build1":{"executable1": ProfileStats, "executable2": ...}, "build2": ...}
+        """
+
+        merged_stats = {self.build.build_name: self.stats}
+
+        try:
+            with open(
+                os.path.join(os.getcwd(), self._get_stats_filename()), "rb"
+            ) as file:
+                obj: dict[str, dict[str, ProfileStats]]
+                obj = pickle.load(file)
+            merged_stats.update(obj)
+        except FileNotFoundError:
+            pass
 
         with open(os.path.join(os.getcwd(), self._get_stats_filename()), "wb") as file:
-            pickle.dump(self.stats, file)
+            pickle.dump(merged_stats, file)
 
     def get_record_filename(self, executable: str) -> str:
         """Gets perf record output file name."""
@@ -591,7 +608,8 @@ class Profiler:
 
     def _get_stats_filename(self) -> str:
         return (
-            tools.escape_filename_part(self.build.build_name) + constants.PERF_STATS_EXT
+            tools.escape_filename_part(tools.project_name(self.project))
+            + constants.PERF_STATS_EXT
         )
 
     def _build_cmd(

--- a/amphimixis/validator.py
+++ b/amphimixis/validator.py
@@ -28,58 +28,55 @@ def validate(config_file_path: str) -> bool:
     :rtype: bool
     :return: Outcome value :\n
          True if config is valid
-         False if config is invalid
+         False if config is invalid or file not exists
     """
 
-    try:
-        with open(config_file_path, "r", encoding="UTF-8") as file:
-
-            file_dict = yaml.safe_load(file)
-
-            build_system = file_dict.get("build_system")
-            if (
-                isinstance(build_system, str)
-                and build_system.lower() not in build_systems_dict
-            ):
-                _warn(f"Invalid build_system: {build_system}")
-
-            runner = file_dict.get("runner")
-            if not isinstance(runner, str) or runner.lower() not in build_systems_dict:
-                _warn(f"Invalid runner: {runner}")
-
-            # validate platforms
-            platforms = file_dict.get("platforms", {})
-            if platforms == {}:
-                _warn("Platforms not found")
-
-            for platform in platforms:
-                _is_valid_platform(platform)
-
-            # validate recipes
-            recipes = file_dict.get("recipes", {})
-            if recipes == {}:
-                _warn("Recipes not found")
-
-            for recipe in recipes:
-                _is_valid_recipe(recipe)
-
-            # validate builds
-            builds = file_dict.get("builds", {})
-            if builds == {}:
-                _warn("Builds not found")
-
-            for build in builds:
-                _is_valid_build(build)
-
-        _logger.info("Validation completed, errors found: %s", _errors_count)
-
-        # True if config is valid (0 errors)
-        # False if config is invalid (>0 errors)
-        return not bool(_errors_count)
-
-    except FileNotFoundError:
-        _logger.error("File not found")
+    if not path.exists(config_file_path):
+        _logger.error("Config file not found")
         return False
+
+    with open(config_file_path, "r", encoding="UTF-8") as file:
+
+        file_dict = yaml.safe_load(file)
+
+        build_system = file_dict.get("build_system")
+        if (
+            isinstance(build_system, str)
+            and build_system.lower() not in build_systems_dict
+        ):
+            _warn(f"Invalid build_system: {build_system}")
+
+        runner = file_dict.get("runner")
+        if not isinstance(runner, str) or runner.lower() not in build_systems_dict:
+            _warn(f"Invalid runner: {runner}")
+
+        # validate platforms
+        platforms = file_dict.get("platforms", {})
+        if platforms == {}:
+            _warn("Platforms not found")
+
+        for platform in platforms:
+            _is_valid_platform(platform)
+
+        # validate recipes
+        recipes = file_dict.get("recipes", {})
+        if recipes == {}:
+            _warn("Recipes not found")
+
+        for recipe in recipes:
+            _is_valid_recipe(recipe)
+
+        # validate builds
+        builds = file_dict.get("builds", {})
+        if builds == {}:
+            _warn("Builds not found")
+
+        for build in builds:
+            _is_valid_build(build)
+
+    _logger.info("Validation completed, errors found: %s", _errors_count)
+
+    return _errors_count == 0
 
 
 def _is_valid_platform(platform: dict[str, int | str]):

--- a/ci/runner.sh
+++ b/ci/runner.sh
@@ -11,9 +11,9 @@ shellcheck "${CI_PATH}"/*.sh
 "${CI_PATH}"/environment_configure.sh
 
 echo -e "${BLUE}Run CI:${NC}"
+"${CI_PATH}"/mdl.sh
 "${CI_PATH}"/black.sh
 "${CI_PATH}"/mypy.sh
 "${CI_PATH}"/pylint.sh
 "${CI_PATH}"/ruff.sh
 "${CI_PATH}"/pytest.sh
-"${CI_PATH}"/mdl.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
 package = true
 
 [tool.mypy]
-disable_error_code = ["import-untyped"]
+disable_error_code = ["import-untyped", "annotation-unchecked"]
 
 [tool.isort]
 profile = "black"

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -39,8 +39,9 @@ def build_executable():
 
 
 @pytest.fixture
-def get_profiler(mocker: pytest_mock.MockerFixture):
+def get_profiler(mocker: pytest_mock.MockerFixture, monkeypatch: pytest.MonkeyPatch):
     def _profiler(path: Path, exec_name: str) -> Profiler:
+        monkeypatch.chdir(path)
         workdir_path_mock = mocker.Mock()
         workdir_path_mock.return_value = str(path)
         mocker.patch("amphimixis.Shell.get_project_workdir", workdir_path_mock)

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -6,7 +6,6 @@ import pytest
 import pytest_mock
 
 import amphimixis
-import amphimixis.profiler
 from amphimixis import Profiler, general
 
 EXECUTABLE_FILENAME = "a.out"
@@ -383,27 +382,6 @@ class TestProfiler:
         assert passed_stats.perf_stat is not None
         assert passed_stats.perf_record_name is not None
 
-    def test_get_record_filename_flattens_nested_path(self, get_shellmocked_profiler):
-        profiler: Profiler = get_shellmocked_profiler()
-
-        assert (
-            profiler.get_record_filename("bin/nested/a.out")
-            == "test_build_bin_nested_a.out.perfdata"
-        )
-
-    def test_get_archive_filename_uses_record_filename(self, get_shellmocked_profiler):
-        profiler: Profiler = get_shellmocked_profiler()
-
-        assert (
-            profiler.get_archive_filename("bin/a.out")
-            == "test_build_bin_a.out.perfdata.tar.bz2"
-        )
-
-    def test_get_stats_filename_uses_build_name(self, get_shellmocked_profiler):
-        profiler: Profiler = get_shellmocked_profiler()
-
-        assert profiler._get_stats_filename() == "test_build.stats"
-
     def test_build_cmd_adds_redirects(self, get_shellmocked_profiler):
         profiler: Profiler = get_shellmocked_profiler()
 
@@ -439,13 +417,15 @@ class TestProfiler:
         self, get_shellmocked_profiler
     ):
         profiler: Profiler = get_shellmocked_profiler()
+        record_filename = profiler.get_record_filename("bin/a.out")
+        script_filename = profiler.get_script_filename("bin/a.out")
 
-        command, filename = profiler._get_script_command("stats.perfdata")
+        command, filename = profiler._get_script_command(record_filename)
 
-        assert filename == "stats.perfdata.scriptout"
+        assert filename == script_filename
         assert (
-            command
-            == "perf --no-pager script -F comm,event,ip,sym,dso,period -G -i stats.perfdata > stats.perfdata.scriptout"
+            command == "perf --no-pager script -F comm,event,ip,sym,dso,period "
+            f"-G -i {record_filename} > {script_filename}"
         )
 
     def test_time_command_keeps_stderr_when_requested(self, get_shellmocked_profiler):
@@ -503,18 +483,21 @@ class TestProfiler:
         self, get_shellmocked_profiler, mocker: pytest_mock.MockerFixture
     ):
         profiler: Profiler = get_shellmocked_profiler()
+        record_filename = profiler.get_record_filename("bin/a.out")
         mocker.patch.object(
             profiler.shell,
             "run",
             return_value=(1, [[]], [["cd failed\n"]]),
         )
 
-        assert profiler.perf_script("stats.perfdata", "/tmp/workdir") == (False, "")
+        assert profiler.perf_script(record_filename, "/tmp/workdir") == (False, "")
 
     def test_perf_script_returns_false_when_script_command_fails(
         self, get_shellmocked_profiler, mocker: pytest_mock.MockerFixture
     ):
         profiler: Profiler = get_shellmocked_profiler()
+        record_filename = profiler.get_record_filename("bin/a.out")
+        script_filename = profiler.get_script_filename("bin/a.out")
         mocker.patch.object(
             profiler.shell,
             "run",
@@ -524,13 +507,14 @@ class TestProfiler:
             ],
         )
 
-        assert profiler.perf_script("stats.perfdata", "/tmp/workdir") == (False, "")
-        assert profiler.cleanup_files == ["/tmp/workdir/stats.perfdata.scriptout"]
+        assert profiler.perf_script(record_filename, "/tmp/workdir") == (False, "")
+        assert profiler.cleanup_files == [f"/tmp/workdir/{script_filename}"]
 
     def test_perf_script_returns_false_when_copy_to_host_fails(
         self, get_shellmocked_profiler, mocker: pytest_mock.MockerFixture
     ):
         profiler: Profiler = get_shellmocked_profiler()
+        record_filename = profiler.get_record_filename("bin/a.out")
         mocker.patch.object(
             profiler.shell,
             "run",
@@ -541,12 +525,14 @@ class TestProfiler:
         )
         mocker.patch.object(profiler.shell, "copy_to_host", return_value=False)
 
-        assert profiler.perf_script("stats.perfdata", "/tmp/workdir") == (False, "")
+        assert profiler.perf_script(record_filename, "/tmp/workdir") == (False, "")
 
     def test_perf_script_returns_output_filename_on_success(
         self, get_shellmocked_profiler, mocker: pytest_mock.MockerFixture
     ):
         profiler: Profiler = get_shellmocked_profiler()
+        record_filename = profiler.get_record_filename("bin/a.out")
+        script_filename = profiler.get_script_filename("bin/a.out")
         mocker.patch.object(
             profiler.shell,
             "run",
@@ -559,9 +545,9 @@ class TestProfiler:
             profiler.shell, "copy_to_host", return_value=True
         )
 
-        assert profiler.perf_script("stats.perfdata", "/tmp/workdir") == (
+        assert profiler.perf_script(record_filename, "/tmp/workdir") == (
             True,
-            "stats.perfdata.scriptout",
+            script_filename,
         )
         copy_to_host.assert_called_once()
 

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -166,11 +166,13 @@ class TestProfiler:
         assert profiler.execution_time(EXECUTABLE_FILENAME, profiler.build_path)
 
         for time_counter in (
-            amphimixis.profiler.Stats.KERNEL_TIME,
-            amphimixis.profiler.Stats.USER_TIME,
-            amphimixis.profiler.Stats.REAL_TIME,
+            "kernel_time",
+            "user_time",
+            "real_time",
         ):
-            assert float(profiler.stats[EXECUTABLE_FILENAME][time_counter]) >= 0
+            assert (
+                float(getattr(profiler.stats[EXECUTABLE_FILENAME], time_counter)) >= 0
+            )
 
     @pytest.mark.parametrize(
         "program, expected",
@@ -188,13 +190,9 @@ class TestProfiler:
         )
 
         assert profiler.execution_time(EXECUTABLE_FILENAME, profiler.build_path)
-
-        assert (
-            float(
-                profiler.stats[EXECUTABLE_FILENAME][amphimixis.profiler.Stats.REAL_TIME]
-            )
-            > expected - 0.1
-        )
+        real_time = profiler.stats[EXECUTABLE_FILENAME].real_time
+        assert real_time is not None
+        assert float(real_time) > expected - 0.1
 
     @pytest.mark.parametrize("program", [C_PROGRAM_SUCCESSFUL_RUN])
     def test_perf_data_collect_updates_dictionary_with_some_data_on_successful_run(
@@ -207,10 +205,7 @@ class TestProfiler:
 
         assert profiler.perf_stat_collect(EXECUTABLE_FILENAME, profiler.build_path)
 
-        assert (
-            profiler.stats[EXECUTABLE_FILENAME].get(amphimixis.profiler.Stats.PERF_STAT)
-            is not None
-        )
+        assert profiler.stats[EXECUTABLE_FILENAME].perf_stat is not None
 
     @pytest.mark.parametrize("program", [C_PROGRAM_SUCCESSFUL_RUN])
     def test_perf_record_collect_creates_valid_perf_data_file(
@@ -371,12 +366,22 @@ class TestProfiler:
 
         assert spies[0].call_count == 2
         assert all(s.call_count == 1 for s in spies[1:])
-        assert (
-            len(profiler.stats[EXECUTABLE_FILENAME + "fail_test"].keys()) == 1
-        ), "Executable that failed smoke test is not skipped"
-        assert (
-            len(profiler.stats[EXECUTABLE_FILENAME + "ok_test"].keys()) == 5
-        ), "Executable that passed smoke test is skipped"
+        failed_stats = profiler.stats[EXECUTABLE_FILENAME + "fail_test"]
+        assert failed_stats.executable_run_success is False
+        assert failed_stats.real_time is None
+        assert failed_stats.user_time is None
+        assert failed_stats.kernel_time is None
+        assert failed_stats.perf_stat is None
+        assert failed_stats.perf_record_name is None
+        assert failed_stats.perf_archive_name is None
+
+        passed_stats = profiler.stats[EXECUTABLE_FILENAME + "ok_test"]
+        assert passed_stats.executable_run_success is True
+        assert passed_stats.real_time is not None
+        assert passed_stats.user_time is not None
+        assert passed_stats.kernel_time is not None
+        assert passed_stats.perf_stat is not None
+        assert passed_stats.perf_record_name is not None
 
     def test_get_record_filename_flattens_nested_path(self, get_shellmocked_profiler):
         profiler: Profiler = get_shellmocked_profiler()


### PR DESCRIPTION
Profiler:
- dynamic column length
- use RISC-V events for riscv architecture run-machines
- match RISC-V `cpu-clock` and hybrid cpu events to general `cycles`
- save profile results in one project file

General:
- filename bijective generation tools 