### PR TITLE
Properly handle password-protected ssh hosts

### DIFF
--- a/amphimixis/shell/paramiko_shell_handler.py
+++ b/amphimixis/shell/paramiko_shell_handler.py
@@ -27,8 +27,8 @@ class _ParamikoHandler(IShellHandler):
                 username=machine.auth.username,
                 password=machine.auth.password,
                 timeout=connect_timeout,
-                look_for_keys=True,
-                allow_agent=True,
+                look_for_keys=(machine.auth.password is None),
+                allow_agent=(machine.auth.password is None),
             )
         except (paramiko.SSHException, socket.error) as e:
             raise paramiko.SSHException(f"Can't connect to ssh {machine}: {e}")

--- a/amphimixis/shell/shell.py
+++ b/amphimixis/shell/shell.py
@@ -302,19 +302,27 @@ class Shell:
 
         port = self.machine.auth.port
         # if None or empty string, ssh-agent is supposed
-        password = self.machine.auth.password or "nopasswd"
+        password = self.machine.auth.password
 
         return self._copy_remote(source, destination, password, port)
 
     def _copy_remote(
-        self, source: str, destination: str, password: str, port: int
+        self, source: str, destination: str, password: str | None, port: int
     ) -> bool:
         self._logger.info("Copying %s -> %s", source, destination)
+        sshcmd = ["ssh", "-o", "StrictHostKeyChecking=no"]
+        if password:
+            sshcmd += [
+                "-o",
+                "PubkeyAuthentication=no",
+                "-o",
+                "PasswordAuthentication=yes",
+            ]
+        sshcmd += ["-p", str(port)]
         error_code = subprocess.call(
-            [
-                "sshpass",
-                "-p",
-                password,
+            ["sshpass"]
+            + (["-p", password] if password else [])
+            + [
                 "rsync",
                 "--checksum",
                 "--archive",
@@ -325,7 +333,7 @@ class Shell:
                 "--compress",
                 "--log-file=./amphimixis.log",
                 "-e",
-                f"ssh -o StrictHostKeyChecking=no -p {port}",
+                " ".join(sshcmd),
                 source,
                 destination,
             ]

--- a/tests/shell_test.py
+++ b/tests/shell_test.py
@@ -267,13 +267,32 @@ class TestShell:
         assert shell._copy_local("/tmp/src", "/tmp/dst") is expected
 
     @pytest.mark.parametrize(("return_code", "expected"), [(0, True), (1, False)])
-    def test_copy_remote_returns_bool_from_rsync(self, return_code, expected, mocker):
+    def test_copy_remote_returns_bool_from_rsync_pwd(
+        self, return_code, expected, mocker
+    ):
         shell = Shell(project, self.remote_machine)
         call = mocker.patch("subprocess.call", return_value=return_code)
 
         assert shell._copy_remote("/tmp/src", "/tmp/dst", "secret", 2222) is expected
         args = call.call_args.args[0]
         assert args[:4] == ["sshpass", "-p", "secret", "rsync"]
+        assert "--checksum" in args
+        assert "--archive" in args
+        assert (
+            "ssh -o StrictHostKeyChecking=no -o PubkeyAuthentication=no -o PasswordAuthentication=yes -p 2222"
+            in args
+        )
+
+    @pytest.mark.parametrize(("return_code", "expected"), [(0, True), (1, False)])
+    def test_copy_remote_returns_bool_from_rsync_key(
+        self, return_code, expected, mocker
+    ):
+        shell = Shell(project, self.remote_machine)
+        call = mocker.patch("subprocess.call", return_value=return_code)
+
+        assert shell._copy_remote("/tmp/src", "/tmp/dst", None, 2222) is expected
+        args = call.call_args.args[0]
+        assert args[:2] == ["sshpass", "rsync"]
         assert "--checksum" in args
         assert "--archive" in args
         assert "ssh -o StrictHostKeyChecking=no -p 2222" in args


### PR DESCRIPTION
If ssh finds a key, it ignores a user-supplied password. Not good. Suggested way:
- if user specified a password, use it.
- if user did not specify any password, use ssh-agent.