### PR TITLE
Shell pipe reading fix

### DIFF
--- a/amphimixis/core/shell/shell.py
+++ b/amphimixis/core/shell/shell.py
@@ -123,7 +123,7 @@ class Shell:
             cmd_stderr: List[str] = []
             while line := self._shell.stdout_readline():
                 self._ui.step()
-                if line[: len(_READING_BARRIER_FLAG)] == _READING_BARRIER_FLAG:
+                if line[:-1] == _READING_BARRIER_FLAG:
                     error_code = int(line[len(_READING_BARRIER_FLAG) + 1 :])
                     if cmd_stdout[-1] == "\n":
                         del cmd_stdout[-1]

--- a/amphimixis/core/shell/shell.py
+++ b/amphimixis/core/shell/shell.py
@@ -3,6 +3,7 @@
 import os
 import socket
 import subprocess
+import threading
 from ctypes import ArgumentError
 from typing import List, Self, Tuple
 
@@ -43,6 +44,7 @@ class Shell:
         self._homedir: str = ""
         self._is_connected: bool = False
         self._is_local: bool = False
+        self._ui_lock = threading.Lock()
 
     def connect(self) -> Self:
         """Connect to the shell of the machine."""
@@ -94,7 +96,6 @@ class Shell:
             OR
             all commands have been executed.
 
-
         :param str *commands: commands to be executed
 
         :rtype: Tuple[int, List[List[str]], List[List[str]]]
@@ -121,30 +122,50 @@ class Shell:
             self._shell.run(f'echo "\n{_READING_BARRIER_FLAG}">&2')
             cmd_stdout: List[str] = []
             cmd_stderr: List[str] = []
-            while line := self._shell.stdout_readline():
-                self._ui.step()
-                if line[:-1] == _READING_BARRIER_FLAG:
-                    error_code = int(line[len(_READING_BARRIER_FLAG) + 1 :])
-                    if cmd_stdout[-1] == "\n":
-                        del cmd_stdout[-1]
-                    else:
-                        cmd_stdout[-1] = cmd_stdout[-1][:-1]
-                    break
-                cmd_stdout.append(line)
-            stdout.append(cmd_stdout)
+            command_error_code: List[int] = []
 
-            while line := self._shell.stderr_readline():
-                self._ui.step()
-                if line[:-1] == _READING_BARRIER_FLAG:
-                    if cmd_stderr[-1] == "\n":
-                        del cmd_stderr[-1]
-                    else:
-                        cmd_stderr[-1] = cmd_stderr[-1][:-1]
-                    break
-                cmd_stderr.append(line)
+            stdout_reader = threading.Thread(
+                target=self._read_stdout_until_barrier,
+                args=(cmd_stdout, command_error_code),
+            )
+            stderr_reader = threading.Thread(
+                target=self._read_stderr_until_barrier, args=(cmd_stderr,)
+            )
+
+            stdout_reader.start()
+            stderr_reader.start()
+            stdout_reader.join()
+            stderr_reader.join()
+
+            error_code = command_error_code[0]
+            stdout.append(cmd_stdout)
             stderr.append(cmd_stderr)
 
         return (error_code, stdout, stderr)
+
+    def _read_stdout_until_barrier(
+        self, output: List[str], error_code: List[int]
+    ) -> None:
+        while line := self._shell.stdout_readline():
+            self._ui.step()
+
+            barrier_error = self._parse_stdout_barrier(line)
+            if barrier_error is not None:
+                error_code.append(barrier_error)
+                self._strip_barrier_separator(output)
+                return
+
+            output.append(line)
+
+    def _read_stderr_until_barrier(self, output: List[str]) -> None:
+        while line := self._shell.stderr_readline():
+            self._ui.step()
+
+            if self._is_stderr_barrier(line):
+                self._strip_barrier_separator(output)
+                return
+
+            output.append(line)
 
     def copy_to_remote(self, source: str, destination: str) -> bool:
         """Send a file or folder to the target machine
@@ -355,3 +376,26 @@ class Shell:
 
         self._logger.info("Success %s -> %s", source, destination)
         return True
+
+    @staticmethod
+    def _parse_stdout_barrier(line: str) -> int | None:
+        stripped = line.strip()
+        prefix = f"{_READING_BARRIER_FLAG}:"
+        if not stripped.startswith(prefix):
+            return None
+        return int(stripped[len(prefix) :])
+
+    @staticmethod
+    def _is_stderr_barrier(line: str) -> bool:
+        return line.strip() == _READING_BARRIER_FLAG
+
+    @staticmethod
+    def _strip_barrier_separator(lines: List[str]) -> None:
+        if not lines:
+            return
+
+        if lines[-1] == "\n":
+            lines.pop()
+            return
+
+        lines[-1] = lines[-1][:-1]

--- a/amphimixis/core/shell/shell_interface.py
+++ b/amphimixis/core/shell/shell_interface.py
@@ -30,3 +30,4 @@ class IShellHandler(ABC):
         :rtype: str
         :return: the next line from stderr
         """
+        raise NotImplementedError

--- a/tests/shell_test.py
+++ b/tests/shell_test.py
@@ -1,7 +1,10 @@
 # pylint: skip-file
 import os
+import shlex
 import socket
 import subprocess
+import sys
+import threading
 from ctypes import ArgumentError
 
 import pytest
@@ -117,6 +120,49 @@ class TestShell:
             READING_BARRIER_STDOUT,
             READING_BARRIER_STDERR,
         ]
+
+    def test_run_drains_real_stderr_pipe_without_deadlock(self):
+        shell = Shell(project, self.local_machine)
+        shell._create_local_shell()
+
+        line_length = 1024
+        line_numbers = 512
+        python_code = (
+            "import sys; "
+            f"sys.stderr.write(('x' * {line_length} + '\\n') * {line_numbers}); "
+            "sys.stderr.flush(); "
+            "print('done')"
+        )
+        command = f"{shlex.quote(sys.executable)} -c {shlex.quote(python_code)}"
+        result = {}
+        exception = []
+
+        def run_command():
+            try:
+                result["value"] = shell.run(command)
+            except Exception as error:  # pragma: no cover - re-raised below
+                exception.append(error)
+
+        thread = threading.Thread(target=run_command, daemon=True)
+        thread.start()
+        thread.join(timeout=10)
+
+        try:
+            if thread.is_alive():
+                pytest.fail("Shell.run() deadlocked while draining stderr")
+
+            if exception:
+                raise exception[0]
+
+            error, stdout, stderr = result["value"]
+
+            assert error == 0
+            assert stdout == [["done\n"]]
+            assert len(stderr) == 1
+            assert len(stderr[0]) == line_numbers
+            assert all(line == ("x" * line_length) + "\n" for line in stderr[0])
+        finally:
+            shell._shell.__del__()
 
     def test_connect_uses_local_handler_for_local_machine(self, mocker):
         handler = FakeHandler()


### PR DESCRIPTION
## Summary

This PR fixes pipe buffer overflow in `Shell.run()` by reading `stdout` and `stderr` in parallel.

## What Changed

- switched shell output handling to parallel `stdout`/`stderr` reading with threads
- extracted barrier parsing/cleanup into helper methods
- added a unit test for parallel stream draining
