### PR TITLE
Docs improving

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,39 +10,52 @@
 
 Amphimixis is an automated project intelligence and evaluation tool for performance and migration readiness. It helps inspect a project for existing infrastructure such as CI, tests, benchmarks, dependencies, and build scripts, then runs builds and collects performance data for further comparison.
 
-> Amphimixis uses `perf` for profiling, makes cross-table with two builds per CPU event for comparison.
+> Amphimixis uses `perf` for profiling and can generate a cross‑table comparing two builds per CPU event.
+
+## Performance cross-table example
+
+The cross‑table below was generated using the configuration file on the right. It compares two builds of a YAML‑based project on a local x86 machine (CMake + Ninja, two builds sharing executables via YAML anchors).
 
 <p align="center">
-  <img src="docs/tinyxml2-cross-table-example.png" alt="Cross-table example" width="800"><br>
+  <img src="docs/tinyxml2-cross-table-example.png" alt="Cross-table example" width="100%">
 </p>
+
+<table width="100%">
+  <tr>
+    <td width="55%">
+      <p>
+        <strong>What does the configuration contain?</strong><br>
+        The file on the right defines:
+        <ul>
+          <li>One x86 platform (address, credentials, SSH port).</li>
+          <li>Two recipes with identical compiler flags (<code>-O2</code>) and the same toolchain (<code>g++</code>).</li>
+          <li>Two builds, each referencing the same recipe, both using an executable list tied to a YAML anchor to avoid duplication.</li>
+        </ul>
+        <strong>Why are there zeros in the cross‑table?</strong><br>
+        The two builds were executed on different architectures: <code>1_1_1</code> on **RISC‑V** and <code>2_2_2</code> on **x86**. Perf events like `cache‑misses` have different naming conventions or are not available on RISC‑V. That is why the first build shows zeros for those metrics, while the second build records actual numbers. The delta column highlights only the differences that appear in both builds, making it easy to spot architecture‑specific behaviour.
+      </p>
+    </td>
+    <td width="45%">
+      <p align="center">
+        <img src="docs/config-example.png" alt="Configuration file example" width="90%">
+        <br>
+        <i>Configuration file (CMake + Ninja)</i>
+      </p>
+    </td>
+  </tr>
+</table>
 
 ## Requirements
 
 - Python 3.12 or later
 - Linux
-- `rsync` on each machine
-- `sshpass` available on the machine where you run Amphimixis, if you connect to remote machines with passwords
-- `perf` and `perf archive`<sup><a href="#note1">1</a></sup> available on each `run_machine`
-- A supported build setup in the target project: CMake as the build system and Make as the low-level runner
+- `rsync` on each machine, `sshpass` on the machine that connects to remote hosts with passwords
+- `perf` and `perf archive` on each `run_machine`
+- Target project must support CMake as the build system and Make or Ninja as the low-level runner
 
-Install system dependencies on each machine before running Amphimixis:
+Installation commands for system dependencies are available in [Troubleshooting → System Dependencies](docs/troubleshooting.md).
 
-```bash
-# on each machine
-apt install rsync
-
-# on the machine where you run Amphimixis
-apt install sshpass
-
-# on each run_machine (provides perf and perf archive)
-apt install linux-tools-common linux-tools
-```
-
-<p id="note1">
-
-1. More about `perf archive` in [Usage guide](docs/usage_guide.md).
-
-## Quick run
+## Quick start
 
 If you want to try Amphimixis right away, create a virtual environment, install the package from GitHub, and run the full pipeline on a target project:
 
@@ -54,73 +67,12 @@ amixis init local
 amixis run /path/to/project --config local.yml
 ```
 
-<p align="left">
+## Documentation
 
-<img align="right" src="docs/config-example.png" alt="Configuration file example" width="300">
-
-## Note
-
-By default, your working directory must have an `input.yml` or other configuration file that you can specify with the `--config` flag. The format is described in [Config instruction](docs/config_instruction.md).
-
-</p>
-
-If your `input.yml` contains remote machines authenticated with SSH keys, start `ssh-agent` in the current shell and add the required keys manually before running `amixis`:
-
-```bash
-eval "$(ssh-agent -s)"
-ssh-add ~/.ssh/id_remote_machine
-```
-
-## What Amphimixis does
-
-Amphimixis can:
-
-- <i>analyze</i> a project for CI, tests, benchmarks, build system configuration, and dependencies
-- <i>build</i> the project with configured recipes and platforms
-- <i>profile</i> executable runs and collect timing and `perf`-based statistics
-- <i>compare</i> profiling outputs produced for different builds and put them into a <u><i>cross-table for each CPU event</i></u>
-
-## Typical usage
-
-Prepare a working directory with an `input.yml` configuration file. The configuration format is described in [Config instruction](docs/config_instruction.md).
-
-Run the full workflow for a project:
-
-```bash
-amixis run /path/to/project
-```
-
-This command:
-
-1. analyzes the project
-1. builds it using the selected configuration
-1. profiles the resulting executables
-1. prints profiling results in the console
-
-To compare two collected `perf` outputs:
-
-```bash
-amixis compare build1.scriptout build2.scriptout --max-rows 10
-```
-
-`compare` accepts exactly two `.scriptout` files. `--max-rows` limits how many symbols with the largest delta are shown for each event.
-
-For step-by-step command examples, custom configuration files, and `--events` usage, see [Usage guide](docs/usage_guide.md).
-
-## Build and run notes
-
-The tool is distributed as a Python package with the `amixis` CLI entry point.
-
-For local development and reproducible checks, the repository uses `uv` and GitHub Actions. The CI configuration is available in [.github/workflows/ci.yml](.github/workflows/ci.yml).
-
-Useful commands during development (run from the repository root, where `pyproject.toml` is located):
-
-```bash
-uv run amixis --help
-uv run pytest
-```
-
-If you want a more detailed walkthrough with installation options, workspace preparation, and command examples, see [Usage guide](docs/usage_guide.md).
+- [Usage guide](docs/usage_guide.md) — installation options, workspace setup, all commands, perf events, SSH auth
+- [Config instruction](docs/config_instruction.md) — full `input.yml` schema reference
+- [Troubleshooting](docs/troubleshooting.md) — common issues and solutions
+- [Contributing guide](CONTRIBUTING.md) — how to contribute, local checks, pull request guidelines
 
 ## Project structure
 
@@ -135,32 +87,16 @@ The repository is organized around a small CLI and several core modules:
 - [amphimixis/core/build_systems](amphimixis/core/build_systems) adapts build systems (CMake, Make, Ninja)
 - [docs](docs) contains user-facing documentation
 
-## Documentation
-
-Additional documentation:
-
-- [Usage guide](docs/usage_guide.md)
-- [Config instruction](docs/config_instruction.md)
-
 ## How To Help
 
-Contributions are welcome.
-
-- Report bugs and suggest improvements through GitHub Issues
-- Open a Pull Request with a clear description of the problem and the proposed change
-- Add or improve tests for new behavior
-- Update documentation when changing CLI behavior or configuration format
-
-Before contributing, make sure local checks pass:
+Contributions are welcome. Before submitting a pull request, make sure local checks pass:
 
 ```bash
 ci/runner.sh
 ```
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on bug reports, pull request guidelines, and test categories.
+
 ## License
 
-The project is distributed under the license in [LICENSE](LICENSE).
-
-## Third-Party Licenses
-
-This project includes dependencies under various licenses. See [NOTICE.md](NOTICE.md) and the [third_party_licenses/](third_party_licenses/) directory for details.
+The project is distributed under the [MIT License](LICENSE). This project includes dependencies under various licenses — see [NOTICE.md](NOTICE.md) and the [third_party_licenses/](third_party_licenses/) directory for details.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,32 @@ Amphimixis is an automated project intelligence and evaluation tool for performa
   <img src="docs/tinyxml2-cross-table-example.png" alt="Cross-table example" width="800"><br>
 </p>
 
+## Requirements
+
+- Python 3.12 or later
+- Linux
+- `rsync` on each machine
+- `sshpass` available on the machine where you run Amphimixis, if you connect to remote machines with passwords
+- `perf` and `perf archive`<sup><a href="#note1">1</a></sup> available on each `run_machine`
+- A supported build setup in the target project: CMake as the build system and Make as the low-level runner
+
+Install system dependencies on each machine before running Amphimixis:
+
+```bash
+# on each machine
+apt install rsync
+
+# on the machine where you run Amphimixis
+apt install sshpass
+
+# on each run_machine (provides perf and perf archive)
+apt install linux-tools-common linux-tools
+```
+
+<p id="note1">
+
+1. More about `perf archive` in [Usage guide](docs/usage_guide.md).
+
 ## Quick run
 
 If you want to try Amphimixis right away, create a virtual environment, install the package from GitHub, and run the full pipeline on a target project:
@@ -44,20 +70,6 @@ If your `input.yml` contains remote machines authenticated with SSH keys, start 
 eval "$(ssh-agent -s)"
 ssh-add ~/.ssh/id_remote_machine
 ```
-
-## Requirements
-
-- Python 3.12 or later
-- Linux
-- `rsync` on each machine
-- `sshpass` available on the machine where you run Amphimixis, if you connect to remote machines with passwords
-- `perf` available on each `run_machine`
-- `perf archive`<sup><a href="#note1">1</a></sup> available on each `run_machine`
-- A supported build setup in the target project: CMake as the build system and Make as the low-level runner
-
-<p id="note1">
-
-1. More about `perf archive` in [Usage guide](docs/usage_guide.md)
 
 ## What Amphimixis does
 
@@ -101,7 +113,7 @@ The tool is distributed as a Python package with the `amixis` CLI entry point.
 
 For local development and reproducible checks, the repository uses `uv` and GitHub Actions. The CI configuration is available in [.github/workflows/ci.yml](.github/workflows/ci.yml).
 
-Useful commands during development:
+Useful commands during development (run from the repository root, where `pyproject.toml` is located):
 
 ```bash
 uv run amixis --help
@@ -114,12 +126,13 @@ If you want a more detailed walkthrough with installation options, workspace pre
 
 The repository is organized around a small CLI and several core modules:
 
-- [amixis.py](amixis.py) is the command-line entry point
-- [amphimixis/analyzer.py](amphimixis/analyzer.py) inspects a target project
-- [amphimixis/builder.py](amphimixis/builder.py) runs configured builds
-- [amphimixis/profiler.py](amphimixis/profiler.py) gathers execution and profiling data
-- [amphimixis/validator.py](amphimixis/validator.py) validates `input.yml`
-- [amphimixis/shell](amphimixis/shell) contains local and remote shell backends
+- [amphimixis/amixis/\_\_main\_\_.py](amphimixis/amixis/__main__.py) is the CLI entry point
+- [amphimixis/core/analyzer.py](amphimixis/core/analyzer.py) inspects a target project
+- [amphimixis/core/builder.py](amphimixis/core/builder.py) runs configured builds
+- [amphimixis/core/profiler.py](amphimixis/core/profiler.py) gathers execution and profiling data
+- [amphimixis/core/validator.py](amphimixis/core/validator.py) validates `input.yml`
+- [amphimixis/core/shell](amphimixis/core/shell) contains local and remote shell backends
+- [amphimixis/core/build_systems](amphimixis/core/build_systems) adapts build systems (CMake, Make, Ninja)
 - [docs](docs) contains user-facing documentation
 
 ## Documentation

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -53,6 +53,7 @@ User Guides
 
 - :doc:`usage_guide`
 - :doc:`config_instruction`
+- :doc:`troubleshooting`
 
 Main Workflows
 --------------
@@ -95,6 +96,7 @@ Supporting Modules
    usage_guide
    config_instruction
    input
+   troubleshooting
 
 .. toctree::
    :maxdepth: 2

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,205 @@
+# Troubleshooting
+
+This page covers common issues and their solutions when using Amphimixis.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [System Dependencies](#system-dependencies)
+- [Build Failures](#build-failures)
+- [Configuration Failures](#configuration-failures)
+- [Profiling Failures](#profiling-failures)
+
+## Installation
+
+### `pip install` fails with a Python version error
+
+Amphimixis requires **Python 3.12 or later**. Check your version:
+
+```bash
+python3 --version
+```
+
+If your system Python is older, install a newer version or use `uv` to manage Python versions:
+
+```bash
+uv python install 3.12
+uv venv --python 3.12
+source .venv/bin/activate
+pip install git+https://github.com/ebzych/amphimixis.git@stable
+```
+
+### The `amixis` command is not found after installation
+
+The entry point may not be on your `PATH`. Activate the virtual environment where you installed the package:
+
+```bash
+source .venv/bin/activate
+amixis --help
+```
+
+If you installed with `pip install --user`, ensure `~/.local/bin` is on your `PATH`.
+
+## System Dependencies
+
+### `perf` command not found
+
+`perf` is part of the Linux kernel tools package. Install it **on each machine** where profiling will run:
+
+```bash
+apt install linux-tools-common linux-tools-generic
+```
+
+### `perf archive` is not available
+
+Some distributions (notably Ubuntu) ship `perf` without `perf archive`. This script is required to resolve build IDs after profiling. Fix it by downloading the script from the Linux kernel repository:
+
+```bash
+sudo mkdir -p /usr/libexec/perf-core
+curl -s https://raw.githubusercontent.com/torvalds/linux/master/tools/perf/perf-archive.sh | sudo tee /usr/libexec/perf-core/perf-archive
+sudo chmod +x /usr/libexec/perf-core/perf-archive
+```
+
+See the [original discussion](https://linux-perf-users.vger.kernel.narkive.com/gjAAds7D/perf-archive-is-not-a-perf-command).
+
+### `rsync` not found on remote machine
+
+`rsync` must be installed **on each machine** referenced in your `input.yml`:
+
+```bash
+apt install rsync
+```
+
+### `sshpass` not found
+
+`sshpass` is required only when connecting to remote machines with password authentication. Install it on the machine where you run Amphimixis:
+
+```bash
+apt install sshpass
+```
+
+If your configuration uses remote machines authenticated with SSH keys, start ssh-agent in the current shell and add the required keys before running the tool:
+
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_remote_machine
+```
+
+## Build Failures
+
+### Unsupported build system detected
+
+Amphimixis currently supports **CMake** and **Make** as build systems, with **Make** and **Ninja** as runners. If your project uses a different build system (e.g., Meson, Gradle, Bazel), you can still try specifying CMake explicitly in `input.yml` if a `CMakeLists.txt` exists:
+
+```yaml
+build_system: CMake
+runner: Make
+```
+
+### CMake configuration fails
+
+Common causes:
+
+- Missing `CMakeLists.txt` in the project root
+- Missing dependencies (libraries, headers) referenced in `CMakeLists.txt`
+- Toolchain not available on the build machine
+
+Check the build log in `amphimixis.log` for the exact error.
+
+### Build succeeds but no executable is found
+
+In `builds`, you can optionally specify an `executables` list for each build. Each path must be relative to that build's output directory, for example `bin/my_app`. If `executables` is omitted, Amphimixis profiles the first executable file it finds in the build directory. To ensure the correct binary is profiled, specify it explicitly:
+
+```yaml
+builds:
+  - build_machine: 1
+    run_machine: 1
+    recipe_id: 1
+    executables:
+      - bin/my_app
+```
+
+## Configuration Failures
+
+### `input.yml` validation fails
+
+Run the validator to see the exact error:
+
+```bash
+amixis validate /path/to/input.yml
+```
+
+Common mistakes:
+
+- Missing required fields: `platforms`, `recipes`, `builds` must be non-empty lists
+- `build_machine` or `run_machine` references a `platform_id` that does not exist
+- `recipe_id` references a recipe that does not exist
+- `port` outside the valid range (1-65535)
+
+### What happens if `build_system` or `runner` is omitted
+
+Amphimixis will auto-detect them from the target project. If the project has a `CMakeLists.txt`, CMake is selected. If a `Makefile` is found, Make is used. The runner defaults to Make if the build system is CMake, or to the project's native runner.
+
+### How to reuse the same `executables` list across multiple builds
+
+Use YAML anchors and aliases to avoid duplication:
+
+```yaml
+executables: &my_executables
+  - bin/my_app
+  - tests/my_benchmark
+
+builds:
+  - build_machine: 1
+    run_machine: 1
+    recipe_id: 1
+    executables: *my_executables
+  - build_machine: 1
+    run_machine: 1
+    recipe_id: 2
+    executables: *my_executables
+```
+
+## Profiling Failures
+
+### Empty or minimal profiling output
+
+This can happen if:
+
+- The executable runs too quickly for `perf` to collect meaningful samples
+- The perf events specified with `--events` are not supported on the current hardware
+- `perf_event_paranoid` is set too high
+
+Check supported events:
+
+```bash
+perf list
+```
+
+Lower the paranoid level if needed (requires root):
+
+```bash
+echo '-1' | sudo tee /proc/sys/kernel/perf_event_paranoid
+```
+
+### `perf` reports "Permission denied"
+
+Set the paranoid level to allow user-space profiling:
+
+```bash
+echo '-1' | sudo tee /proc/sys/kernel/perf_event_paranoid
+```
+
+This setting does not persist across reboots. To make it permanent, add to `/etc/sysctl.conf`:
+
+```
+kernel.perf_event_paranoid = -1
+```
+
+### Comparing outputs from different machines
+
+The `amixis compare` command works with `.scriptout` files regardless of which machine they were collected on. Ensure both files use the same perf events for meaningful comparison:
+
+```bash
+amixis compare build1.scriptout build2.scriptout --max-rows 10
+```

--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -1,5 +1,20 @@
 # Usage guide
 
+## Table of Contents
+
+- [Choose an installation method](#choose-an-installation-method)
+- [Prepare a workspace](#prepare-a-workspace)
+- [Run the main workflow](#run-the-main-workflow)
+- [Run individual commands](#run-individual-commands)
+- [Work with perf events](#work-with-perf-events)
+- [Compare profiling outputs](#compare-profiling-outputs)
+- [Add a toolchain](#add-a-toolchain)
+- [Clean build directories](#clean-build-directories)
+
+---
+
+> If you encounter issues while using Amphimixis, see [Troubleshooting](troubleshooting.md) for common problems and solutions.
+
 ## Choose an installation method
 
 For most users, the recommended path is to create a virtual environment and install directly from GitHub:
@@ -35,37 +50,9 @@ Run Amphimixis from a working directory that contains your configuration and any
 
 ### Make sure the required system tools are available
 
-- `rsync` per machine
-- `perf` and `perf archive` on each `run_machine`
-- `sshpass` if your remote connections use passwords
+Required tools: `rsync` on each machine, `perf` and `perf archive` on each `run_machine`, and optionally `sshpass` for password-based SSH connections.
 
-```bash
-# on the machine where you run Amphimixis
-apt install sshpass
-```
-
-```bash
-# on each `run_machine`
-apt install linux-tools-common linux-tools
-```
-
-```bash
-# on each machine
-apt install rsync
-```
-
-### perf archive
-
-Check<sup><a href="#note1">1</a></sup> your system for the presence of a `perf archive` by executing this command. If you have problems with this tool, you can use this command that will put the script `perf archive` from the official Linux repository in the right place on your system:
-
-```bash
-mkdir -p /usr/libexec/perf-core
-curl -s https://raw.githubusercontent.com/torvalds/linux/master/tools/perf/perf-archive.sh | sudo tee /usr/libexec/perf-core/perf-archive
-```
-
-<p id="note1">
-
-1. Ubuntu users are experiencing issues with `perf archive`: <a href="https://linux-perf-users.vger.kernel.narkive.com/gjAAds7D/perf-archive-is-not-a-perf-command">linux-perf-users.vger.kernel.narkive.com/perf-archive-is-not-a-perf-command</a>
+See [Troubleshooting → System Dependencies](troubleshooting.md) for installation commands and the `perf archive` setup.
 
 ### Create a configuration file
 
@@ -100,27 +87,17 @@ At minimum, `input.yml` should describe:
 
 In `builds`, you can optionally specify an `executables` list for each build. Each path must be relative to that build's output directory, for example `bin/my_app`. If `executables` is omitted, Amphimixis profiles the first executable file it finds in the build directory.
 
-If your configuration uses remote machines authenticated with SSH keys, start `ssh-agent` in the current shell and add the required keys before running the tool:
-
-```bash
-eval "$(ssh-agent -s)"
-ssh-add ~/.ssh/id_remote_machine
-```
-
 ## Run the main workflow
-
-To analyze, build, and profile a project in one command:
 
 ```bash
 amixis run /path/to/project
 ```
 
-The full pipeline:
+Use `--config` to specify a custom configuration file path:
 
-1. analyzes the project
-1. builds it using the selected configuration
-1. profiles the resulting executables
-1. prints profiling results in the console
+```bash
+amixis run --config ./my_input.yml /path/to/project
+```
 
 ## Run individual commands
 
@@ -146,12 +123,6 @@ Validate a configuration file:
 
 ```bash
 amixis validate /path/to/input/config
-```
-
-Specify the path to the configuration file:
-
-```bash
-amixis run --config ./my_input.yml /path/to/project
 ```
 
 ## Work with perf events


### PR DESCRIPTION
- Add `docs/troubleshooting.md` — troubleshooting guide (common issues, perf, SSH; build, configuration and profiling failures)

- Move `Requirements` section before `Quick start`

- Refactoring and improving `README.md`, `usage_guide.md` for better readability